### PR TITLE
feat(hocr): add a package for parsing, manipulation, and generation of hOCR data

### DIFF
--- a/pkg/hocr/generate.go
+++ b/pkg/hocr/generate.go
@@ -1,0 +1,32 @@
+package hocr
+
+import (
+	"bytes"
+	"embed"
+	"fmt"
+	"strings"
+	"text/template"
+)
+
+//go:embed templates/hocr.tmpl
+var templateFS embed.FS
+
+// GenerateHOCRDocument creates an hOCR HTML document from the HOCR struct
+// Uses the embedded template to generate a complete HTML document
+func GenerateHOCRDocument(doc *HOCR) (string, error) {
+	// Set up the template with a helper function
+	tmpl, err := template.New("hocr.tmpl").Funcs(template.FuncMap{
+		"trim": strings.TrimSpace,
+	}).ParseFS(templateFS, "templates/hocr.tmpl")
+	if err != nil {
+		return "", fmt.Errorf("error parsing hOCR template: %w", err)
+	}
+
+	// Render the template with the hOCR data
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, doc); err != nil {
+		return "", fmt.Errorf("error rendering hOCR template: %w", err)
+	}
+
+	return buf.String(), nil
+}

--- a/pkg/hocr/helpers.go
+++ b/pkg/hocr/helpers.go
@@ -1,0 +1,102 @@
+package hocr
+
+import (
+	"strings"
+)
+
+// ExtractHOCRText extracts all text from an HOCR document
+// The text is ordered by page, with paragraphs separated by newlines
+// and pages separated by double newlines
+func ExtractHOCRText(hocrDoc *HOCR) string {
+	var builder strings.Builder
+
+	for _, page := range hocrDoc.Pages {
+		// Track processed content to avoid duplication
+		processedContent := make(map[string]bool)
+
+		// Extract text from areas (which may contain paragraphs and lines)
+		for _, area := range page.Areas {
+			extractAreaText(&builder, area, processedContent)
+		}
+
+		// Extract text from paragraphs directly on the page
+		for _, para := range page.Paragraphs {
+			extractParagraphText(&builder, para, processedContent)
+		}
+
+		// Extract text from lines directly on the page
+		for _, line := range page.Lines {
+			lineKey := getLineKey(line)
+			if !processedContent[lineKey] {
+				extractLineText(&builder, line)
+				processedContent[lineKey] = true
+			}
+		}
+
+		// Add a page break
+		builder.WriteString("\n\n")
+	}
+
+	return builder.String()
+}
+
+// extractAreaText processes text from an area, including its paragraphs and lines
+func extractAreaText(builder *strings.Builder, area Area, processed map[string]bool) {
+	// Process paragraphs in the area
+	for _, para := range area.Paragraphs {
+		extractParagraphText(builder, para, processed)
+	}
+
+	// Process lines directly in the area
+	for _, line := range area.Lines {
+		lineKey := getLineKey(line)
+		if !processed[lineKey] {
+			extractLineText(builder, line)
+			processed[lineKey] = true
+		}
+	}
+
+	// Process words directly in the area (rare, but possible)
+	if len(area.Words) > 0 {
+		for _, word := range area.Words {
+			builder.WriteString(word.Text)
+			builder.WriteString(" ")
+		}
+		builder.WriteString("\n")
+	}
+}
+
+// extractParagraphText processes text from a paragraph and its lines
+func extractParagraphText(builder *strings.Builder, para Paragraph, processed map[string]bool) {
+	// Process lines in the paragraph
+	for _, line := range para.Lines {
+		lineKey := getLineKey(line)
+		if !processed[lineKey] {
+			extractLineText(builder, line)
+			processed[lineKey] = true
+		}
+	}
+
+	// Process words directly in the paragraph (if any)
+	if len(para.Words) > 0 {
+		for _, word := range para.Words {
+			builder.WriteString(word.Text)
+			builder.WriteString(" ")
+		}
+		builder.WriteString("\n")
+	}
+}
+
+// extractLineText processes text from a line and its words
+func extractLineText(builder *strings.Builder, line Line) {
+	for _, word := range line.Words {
+		builder.WriteString(word.Text)
+		builder.WriteString(" ")
+	}
+	builder.WriteString("\n")
+}
+
+// getLineKey generates a unique key for a line to avoid duplication
+func getLineKey(line Line) string {
+	return line.ID
+}

--- a/pkg/hocr/hocr.go
+++ b/pkg/hocr/hocr.go
@@ -1,0 +1,28 @@
+// Package hocr implements parsing, manipulation, and generation of hOCR data,
+// which is an HTML-based standard format for representing OCR results.
+//
+// This package provides:
+//
+// - A complete object model representing the hOCR hierarchy
+// - Functions for parsing hOCR HTML into structured Go types
+// - Functions for generating valid hOCR HTML from Go structures
+// - Utilities for working with bounding boxes and positional data
+//
+// The package implements the hierarchical structure defined in the hOCR format:
+// Document → Pages → Areas → Paragraphs → Lines → Words, with metadata at each level.
+//
+// Key Types:
+//
+// - HOCR: Top-level structure representing an entire hOCR document
+// - Page: Represents a single page with class 'ocr_page'
+// - Area: Represents a content area with class 'ocr_carea'
+// - Paragraph: Represents a paragraph with class 'ocr_par'
+// - Line: Represents a line of text with class 'ocr_line'
+// - Word: Represents a single word with class 'ocrx_word'
+// - BoundingBox: Represents a rectangle with coordinates for positioning elements
+//
+// Main Functions:
+//
+// - ParseHOCR: Parses hOCR data from HTML into the object model
+// - GenerateHOCRDocument: Generates valid hOCR HTML from the object model
+package hocr

--- a/pkg/hocr/parse.go
+++ b/pkg/hocr/parse.go
@@ -1,0 +1,562 @@
+package hocr
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"golang.org/x/net/html"
+	"golang.org/x/text/encoding/charmap"
+)
+
+// ParseHOCR converts raw hOCR data into a structured HOCR object.
+func ParseHOCR(data []byte) (HOCR, error) {
+	var result HOCR
+	result.Metadata = make(map[string]string)
+
+	// Figure out the character encoding
+	content := string(data)
+	encoding := "utf-8"
+	if strings.Contains(content, "charset=") {
+		metaStart := strings.Index(content, "charset=") + len("charset=")
+		if metaStart > -1 && len(content) > metaStart+10 {
+			encSnippet := content[metaStart : metaStart+20]
+			enc := strings.ToLower(strings.FieldsFunc(encSnippet, func(r rune) bool {
+				return r == '"' || r == ';' || r == '\'' || r == '>'
+			})[0])
+			if enc != "" {
+				encoding = enc
+			}
+		}
+	}
+
+	// Convert to UTF-8 if needed
+	var decoded []byte
+	var err error
+	if encoding != "utf-8" {
+		decoder := charmap.ISO8859_1.NewDecoder()
+		decoded, err = decoder.Bytes(data)
+		if err != nil {
+			return result, fmt.Errorf("failed to decode %s: %w", encoding, err)
+		}
+	} else {
+		decoded = data
+	}
+
+	doc, err := html.Parse(strings.NewReader(string(decoded)))
+	if err != nil {
+		return result, err
+	}
+
+	// Extract document metadata from the head section
+	extractDocumentMeta(&result, doc)
+
+	// Find and process all ocr_page elements
+	var findPages func(*html.Node)
+	findPages = func(n *html.Node) {
+		if n.Type == html.ElementNode && n.Data == "div" {
+			isOcrPage := false
+			for _, a := range n.Attr {
+				if a.Key == "class" && strings.Contains(a.Val, "ocr_page") {
+					isOcrPage = true
+					break
+				}
+			}
+			if isOcrPage {
+				page, err := processPage(n)
+				if err == nil {
+					result.Pages = append(result.Pages, page)
+				}
+				return
+			}
+		}
+		for c := n.FirstChild; c != nil; c = c.NextSibling {
+			findPages(c)
+		}
+	}
+	findPages(doc)
+
+	if len(result.Pages) == 0 {
+		return result, fmt.Errorf("no ocr_page elements found in HOCR data")
+	}
+	return result, nil
+}
+
+// ParseTitle breaks down an hOCR title attribute into its components
+// Example input: "bbox 100 200 300 400; x_wconf 95"
+func ParseTitle(title string) map[string][]string {
+	result := make(map[string][]string)
+	parts := strings.Split(title, ";")
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+
+		items := strings.Fields(part)
+		if len(items) > 0 {
+			key := items[0]
+			values := items[1:]
+			result[key] = values
+		}
+	}
+
+	return result
+}
+
+// ParseBoundingBoxFromTitle extracts a bounding box from a title string
+// Returns a structured BoundingBox object or nil if extraction fails
+func ParseBoundingBoxFromTitle(title string) *BoundingBox {
+	props := ParseTitle(title)
+	if bbox, ok := props["bbox"]; ok && len(bbox) >= 4 {
+		x1, _ := strconv.ParseFloat(bbox[0], 64)
+		y1, _ := strconv.ParseFloat(bbox[1], 64)
+		x2, _ := strconv.ParseFloat(bbox[2], 64)
+		y2, _ := strconv.ParseFloat(bbox[3], 64)
+		result := NewBoundingBox(x1, y1, x2, y2)
+		return &result
+	}
+	return nil
+}
+
+// extractDocumentMeta extracts document-level metadata from the head section
+func extractDocumentMeta(result *HOCR, doc *html.Node) {
+	var findHead func(*html.Node) *html.Node
+	findHead = func(n *html.Node) *html.Node {
+		if n.Type == html.ElementNode && n.Data == "head" {
+			return n
+		}
+		for c := n.FirstChild; c != nil; c = c.NextSibling {
+			if found := findHead(c); found != nil {
+				return found
+			}
+		}
+		return nil
+	}
+
+	// Check for lang attribute on the html tag
+	var findHTMLLang func(*html.Node)
+	findHTMLLang = func(n *html.Node) {
+		if n.Type == html.ElementNode && n.Data == "html" {
+			for _, a := range n.Attr {
+				if a.Key == "lang" || a.Key == "xml:lang" {
+					result.Language = a.Val
+					return
+				}
+			}
+		}
+		// Only check direct children of the document node
+		if n.Parent == nil {
+			for c := n.FirstChild; c != nil; c = c.NextSibling {
+				findHTMLLang(c)
+			}
+		}
+	}
+	findHTMLLang(doc)
+
+	head := findHead(doc)
+	if head == nil {
+		return
+	}
+
+	// Extract title, language, description, etc.
+	for c := head.FirstChild; c != nil; c = c.NextSibling {
+		if c.Type == html.ElementNode {
+			switch c.Data {
+			case "title":
+				if c.FirstChild != nil {
+					result.Title = c.FirstChild.Data
+				}
+			case "meta":
+				name := ""
+				content := ""
+				for _, attr := range c.Attr {
+					if attr.Key == "name" {
+						name = attr.Val
+					} else if attr.Key == "content" {
+						content = attr.Val
+					}
+				}
+				if name != "" && content != "" {
+					if name == "ocr-system" || name == "ocr-capabilities" ||
+						name == "ocr-number-of-pages" || name == "ocr-langs" {
+						result.Metadata[name] = content
+					} else if name == "description" {
+						result.Description = content
+					} else if name == "dc.language" {
+						result.Language = content
+					}
+				}
+			}
+		}
+	}
+}
+
+// processPage extracts page information and its children (areas, lines, words)
+func processPage(n *html.Node) (Page, error) {
+	page := Page{
+		Metadata: make(map[string]string),
+	}
+
+	// Extract page attributes
+	for _, attr := range n.Attr {
+		if attr.Key == "id" {
+			page.ID = attr.Val
+		} else if attr.Key == "lang" {
+			page.Lang = attr.Val
+		} else if attr.Key == "title" {
+			page.Title = attr.Val
+
+			// Extract bbox using the ParseBoundingBoxFromTitle function
+			if bbox := ParseBoundingBoxFromTitle(attr.Val); bbox != nil {
+				page.BBox = *bbox
+			}
+
+			// Extract other properties from title
+			props := ParseTitle(attr.Val)
+			if image, ok := props["image"]; ok && len(image) > 0 {
+				page.ImageName = image[0]
+			}
+			if ppageno, ok := props["ppageno"]; ok && len(ppageno) > 0 {
+				page.PageNumber, _ = strconv.Atoi(ppageno[0])
+			}
+		}
+	}
+
+	// Process areas, paragraphs, lines directly under the page
+	var areaNodes []*html.Node
+	var paragraphNodes []*html.Node
+	var lineNodes []*html.Node
+
+	var collectNodes func(*html.Node)
+	collectNodes = func(node *html.Node) {
+		if node.Type == html.ElementNode {
+			class := getAttrVal(node, "class")
+			if strings.Contains(class, "ocr_carea") {
+				areaNodes = append(areaNodes, node)
+				return
+			} else if strings.Contains(class, "ocr_par") {
+				paragraphNodes = append(paragraphNodes, node)
+				return
+			} else if strings.Contains(class, "ocr_line") {
+				lineNodes = append(lineNodes, node)
+				return
+			}
+		}
+		for c := node.FirstChild; c != nil; c = c.NextSibling {
+			collectNodes(c)
+		}
+	}
+
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		collectNodes(c)
+	}
+
+	// Process areas
+	for _, areaNode := range areaNodes {
+		area, err := processArea(areaNode)
+		if err == nil {
+			page.Areas = append(page.Areas, area)
+		}
+	}
+
+	// Process paragraphs directly under the page
+	for _, paragraphNode := range paragraphNodes {
+		paragraph, err := processParagraph(paragraphNode)
+		if err == nil {
+			page.Paragraphs = append(page.Paragraphs, paragraph)
+		}
+	}
+
+	// Process any lines that don't belong to an area, block, or paragraph
+	for _, lineNode := range lineNodes {
+		line, err := processLine(lineNode)
+		if err == nil {
+			page.Lines = append(page.Lines, line)
+		}
+	}
+
+	return page, nil
+}
+
+// processArea extracts area information and its children (paragraphs, lines, words)
+func processArea(n *html.Node) (Area, error) {
+	area := Area{
+		Metadata: make(map[string]string),
+	}
+
+	// Extract area attributes
+	for _, attr := range n.Attr {
+		if attr.Key == "id" {
+			area.ID = attr.Val
+		} else if attr.Key == "lang" {
+			area.Lang = attr.Val
+		} else if attr.Key == "title" {
+			// Extract bounding box using the ParseBoundingBoxFromTitle function
+			if bbox := ParseBoundingBoxFromTitle(attr.Val); bbox != nil {
+				area.BBox = *bbox
+			}
+
+			// Store other properties in metadata
+			props := ParseTitle(attr.Val)
+			for k, v := range props {
+				if k != "bbox" {
+					area.Metadata[k] = strings.Join(v, " ")
+				}
+			}
+		}
+	}
+
+	// Find paragraphs, lines and words in this area
+	var paragraphNodes []*html.Node
+	var lineNodes []*html.Node
+	var wordNodes []*html.Node
+
+	var collectNodes func(*html.Node)
+	collectNodes = func(node *html.Node) {
+		if node.Type == html.ElementNode {
+			class := getAttrVal(node, "class")
+			if strings.Contains(class, "ocr_par") {
+				paragraphNodes = append(paragraphNodes, node)
+				return
+			} else if strings.Contains(class, "ocr_line") {
+				lineNodes = append(lineNodes, node)
+				return
+			} else if strings.Contains(class, "ocrx_word") {
+				wordNodes = append(wordNodes, node)
+				return
+			}
+		}
+		for c := node.FirstChild; c != nil; c = c.NextSibling {
+			collectNodes(c)
+		}
+	}
+
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		collectNodes(c)
+	}
+
+	// Process paragraphs
+	for _, paragraphNode := range paragraphNodes {
+		paragraph, err := processParagraph(paragraphNode)
+		if err == nil {
+			area.Paragraphs = append(area.Paragraphs, paragraph)
+		}
+	}
+
+	// Process lines that are directly under the area
+	for _, lineNode := range lineNodes {
+		line, err := processLine(lineNode)
+		if err == nil {
+			area.Lines = append(area.Lines, line)
+		}
+	}
+
+	// Process any words directly under the area (no parent line)
+	for _, wordNode := range wordNodes {
+		word, err := processWord(wordNode)
+		if err == nil {
+			area.Words = append(area.Words, word)
+		}
+	}
+
+	return area, nil
+}
+
+// processParagraph extracts paragraph information and its children (lines, words)
+func processParagraph(n *html.Node) (Paragraph, error) {
+	paragraph := Paragraph{
+		Metadata: make(map[string]string),
+	}
+
+	// Extract paragraph attributes
+	for _, attr := range n.Attr {
+		if attr.Key == "id" {
+			paragraph.ID = attr.Val
+		} else if attr.Key == "lang" {
+			paragraph.Lang = attr.Val
+		} else if attr.Key == "title" {
+			// Extract bounding box using the ParseBoundingBoxFromTitle function
+			if bbox := ParseBoundingBoxFromTitle(attr.Val); bbox != nil {
+				paragraph.BBox = *bbox
+			}
+
+			// Store other properties in metadata
+			props := ParseTitle(attr.Val)
+			for k, v := range props {
+				if k != "bbox" {
+					paragraph.Metadata[k] = strings.Join(v, " ")
+				}
+			}
+		}
+	}
+
+	// Find lines and words in this paragraph
+	var lineNodes []*html.Node
+	var wordNodes []*html.Node
+
+	var collectNodes func(*html.Node)
+	collectNodes = func(node *html.Node) {
+		if node.Type == html.ElementNode {
+			class := getAttrVal(node, "class")
+			if strings.Contains(class, "ocr_line") {
+				lineNodes = append(lineNodes, node)
+				return
+			} else if strings.Contains(class, "ocrx_word") {
+				wordNodes = append(wordNodes, node)
+				return
+			}
+		}
+		for c := node.FirstChild; c != nil; c = c.NextSibling {
+			collectNodes(c)
+		}
+	}
+
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		collectNodes(c)
+	}
+
+	// Process lines
+	for _, lineNode := range lineNodes {
+		line, err := processLine(lineNode)
+		if err == nil {
+			paragraph.Lines = append(paragraph.Lines, line)
+		}
+	}
+
+	// Process any words directly under the paragraph (no parent line)
+	for _, wordNode := range wordNodes {
+		word, err := processWord(wordNode)
+		if err == nil {
+			paragraph.Words = append(paragraph.Words, word)
+		}
+	}
+
+	return paragraph, nil
+}
+
+// processLine extracts line information and its words
+func processLine(n *html.Node) (Line, error) {
+	line := Line{
+		Metadata: make(map[string]string),
+	}
+
+	// Extract line attributes
+	for _, attr := range n.Attr {
+		if attr.Key == "id" {
+			line.ID = attr.Val
+		} else if attr.Key == "lang" {
+			line.Lang = attr.Val
+		} else if attr.Key == "title" {
+			// Extract bounding box using the ParseBoundingBoxFromTitle function
+			if bbox := ParseBoundingBoxFromTitle(attr.Val); bbox != nil {
+				line.BBox = *bbox
+			}
+
+			// Extract other properties from title
+			props := ParseTitle(attr.Val)
+			if baseline, ok := props["baseline"]; ok && len(baseline) > 0 {
+				line.Baseline = strings.Join(baseline, " ")
+			}
+
+			// Store other properties in metadata
+			for k, v := range props {
+				if k != "bbox" && k != "baseline" {
+					line.Metadata[k] = strings.Join(v, " ")
+				}
+			}
+		}
+	}
+
+	// Process all word elements in this line
+	var extractWords func(*html.Node)
+	extractWords = func(node *html.Node) {
+		if node.Type == html.ElementNode {
+			for _, a := range node.Attr {
+				if a.Key == "class" && strings.Contains(a.Val, "ocrx_word") {
+					word, err := processWord(node)
+					if err == nil {
+						line.Words = append(line.Words, word)
+					}
+					return
+				}
+			}
+		}
+		for c := node.FirstChild; c != nil; c = c.NextSibling {
+			extractWords(c)
+		}
+	}
+
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		extractWords(c)
+	}
+
+	return line, nil
+}
+
+// Process a word element and extract its text and properties
+func processWord(n *html.Node) (Word, error) {
+	word := Word{
+		Metadata: make(map[string]string),
+	}
+
+	// Extract word attributes
+	for _, attr := range n.Attr {
+		if attr.Key == "id" {
+			word.ID = attr.Val
+		} else if attr.Key == "lang" {
+			word.Lang = attr.Val
+		} else if attr.Key == "title" {
+			// Extract bounding box using the ParseBoundingBoxFromTitle function
+			if bbox := ParseBoundingBoxFromTitle(attr.Val); bbox != nil {
+				word.BBox = *bbox
+			}
+
+			// Extract other properties from title
+			props := ParseTitle(attr.Val)
+			if conf, ok := props["x_wconf"]; ok && len(conf) > 0 {
+				word.Confidence, _ = strconv.ParseFloat(conf[0], 64)
+			}
+			if lang, ok := props["lang"]; ok && len(lang) > 0 {
+				word.Lang = lang[0]
+			}
+
+			// Store other properties in metadata
+			for k, v := range props {
+				if k != "bbox" && k != "x_wconf" && k != "lang" {
+					word.Metadata[k] = strings.Join(v, " ")
+				}
+			}
+		}
+	}
+
+	// Get the actual text content
+	if n.FirstChild != nil {
+		word.Text = extractTextContent(n)
+	}
+
+	return word, nil
+}
+
+// extractTextContent gets all text from a node and its children
+func extractTextContent(n *html.Node) string {
+	if n.Type == html.TextNode {
+		return strings.TrimSpace(n.Data)
+	}
+
+	var text string
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		text += extractTextContent(c)
+	}
+	return strings.TrimSpace(text)
+}
+
+// Get the value of a specific attribute from a node
+func getAttrVal(n *html.Node, attrName string) string {
+	for _, attr := range n.Attr {
+		if attr.Key == attrName {
+			return attr.Val
+		}
+	}
+	return ""
+}

--- a/pkg/hocr/templates/hocr.tmpl
+++ b/pkg/hocr/templates/hocr.tmpl
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="{{ if .Language }}{{ .Language }}{{ else }}unknown{{ end }}" lang="{{ if .Language }}{{ .Language }}{{ else }}unknown{{ end }}">
+<head>
+    <title>{{ if .Title }}{{ .Title }}{{ else }}Document OCR{{ end }}</title>
+    <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
+    {{- range $key, $value := .Metadata }}
+    <meta name="{{ $key }}" content="{{ $value }}" />
+    {{- end }}
+    {{- if not (index .Metadata "ocr-system") }}
+    <meta name="ocr-system" content="hOCR" />
+    {{- end }}
+    {{- if not (index .Metadata "ocr-number-of-pages") }}
+    <meta name="ocr-number-of-pages" content="{{ len .Pages }}" />
+    {{- end }}
+    {{- if not (index .Metadata "ocr-langs") }}
+    <meta name="ocr-langs" content="{{ or .Language "unknown" }}" />
+    {{- end }}
+    {{- if .Description }}
+    <meta name="description" content="{{ .Description }}" />
+    {{- end }}
+</head>
+<body>
+    {{- range $pageIndex, $page := .Pages }}
+    <div class='{{ $page.Class }}' id='{{ $page.ID }}'{{ if $page.Lang }} lang='{{ $page.Lang }}'{{ end }} title='bbox {{ $page.BBox.X1 }} {{ $page.BBox.Y1 }} {{ $page.BBox.X2 }} {{ $page.BBox.Y2 }}{{ if $page.ImageName }}; image {{ $page.ImageName }}{{ end }}{{ if gt $page.PageNumber 0 }}; ppageno {{ $page.PageNumber }}{{ end }}'>
+        {{- range $areaIndex, $area := $page.Areas }}
+        <div class='{{ $area.Class }}' id='{{ $area.ID }}'{{ if $area.Lang }} lang='{{ $area.Lang }}'{{ end }} title='bbox {{ $area.BBox.X1 }} {{ $area.BBox.Y1 }} {{ $area.BBox.X2 }} {{ $area.BBox.Y2 }}'>
+            {{- range $paragraphIndex, $paragraph := $area.Paragraphs }}
+            <p class='{{ $paragraph.Class }}' id='{{ $paragraph.ID }}'{{ if $paragraph.Lang }} lang='{{ $paragraph.Lang }}'{{ end }} title='bbox {{ $paragraph.BBox.X1 }} {{ $paragraph.BBox.Y1 }} {{ $paragraph.BBox.X2 }} {{ $paragraph.BBox.Y2 }}'>
+                {{- range $lineIndex, $line := $paragraph.Lines }}
+                <span class='{{ $line.Class }}' id='{{ $line.ID }}'{{ if $line.Lang }} lang='{{ $line.Lang }}'{{ end }} title='bbox {{ $line.BBox.X1 }} {{ $line.BBox.Y1 }} {{ $line.BBox.X2 }} {{ $line.BBox.Y2 }}{{ if $line.Baseline }}; baseline {{ $line.Baseline }}{{ end }}'>{{ range $wordIndex, $word := $line.Words }}<span class='{{ $word.Class }}' id='{{ $word.ID }}'{{ if $word.Lang }} lang='{{ $word.Lang }}'{{ end }} title='bbox {{ $word.BBox.X1 }} {{ $word.BBox.Y1 }} {{ $word.BBox.X2 }} {{ $word.BBox.Y2 }}{{ if ne $word.Confidence 0.0 }}; x_wconf {{ printf "%.0f" $word.Confidence }}{{ end }}'>{{ $word.Text }}</span>{{ end }}</span>
+                {{- end }}
+                
+                {{- if $paragraph.Words }}
+                <!-- Direct words in paragraph (if no lines) -->
+                {{- range $wordIndex, $word := $paragraph.Words }}
+                <span class='{{ $word.Class }}' id='{{ $word.ID }}'{{ if $word.Lang }} lang='{{ $word.Lang }}'{{ end }} title='bbox {{ $word.BBox.X1 }} {{ $word.BBox.Y1 }} {{ $word.BBox.X2 }} {{ $word.BBox.Y2 }}{{ if ne $word.Confidence 0.0 }}; x_wconf {{ printf "%.0f" $word.Confidence }}{{ end }}'>{{ $word.Text }}</span>
+                {{- end }}
+                {{- end }}
+            </p>
+            {{- end }}
+
+            {{- range $lineIndex, $line := $area.Lines }}
+            <span class='{{ $line.Class }}' id='{{ $line.ID }}'{{ if $line.Lang }} lang='{{ $line.Lang }}'{{ end }} title='bbox {{ $line.BBox.X1 }} {{ $line.BBox.Y1 }} {{ $line.BBox.X2 }} {{ $line.BBox.Y2 }}{{ if $line.Baseline }}; baseline {{ $line.Baseline }}{{ end }}'>{{ range $wordIndex, $word := $line.Words }}<span class='{{ $word.Class }}' id='{{ $word.ID }}'{{ if $word.Lang }} lang='{{ $word.Lang }}'{{ end }} title='bbox {{ $word.BBox.X1 }} {{ $word.BBox.Y1 }} {{ $word.BBox.X2 }} {{ $word.BBox.Y2 }}{{ if ne $word.Confidence 0.0 }}; x_wconf {{ printf "%.0f" $word.Confidence }}{{ end }}'>{{ $word.Text }}</span>{{ end }}</span>
+            {{- end }}
+            
+            {{- if $area.Words }}
+            <!-- Direct words in area (if no lines) -->
+            {{- range $wordIndex, $word := $area.Words }}
+            <span class='{{ $word.Class }}' id='{{ $word.ID }}'{{ if $word.Lang }} lang='{{ $word.Lang }}'{{ end }} title='bbox {{ $word.BBox.X1 }} {{ $word.BBox.Y1 }} {{ $word.BBox.X2 }} {{ $word.BBox.Y2 }}{{ if ne $word.Confidence 0.0 }}; x_wconf {{ printf "%.0f" $word.Confidence }}{{ end }}'>{{ $word.Text }}</span>
+            {{- end }}
+            {{- end }}
+        </div>
+        {{- end }}
+
+
+
+        {{- range $paragraphIndex, $paragraph := $page.Paragraphs }}
+        <p class='{{ $paragraph.Class }}' id='{{ $paragraph.ID }}'{{ if $paragraph.Lang }} lang='{{ $paragraph.Lang }}'{{ end }} title='bbox {{ $paragraph.BBox.X1 }} {{ $paragraph.BBox.Y1 }} {{ $paragraph.BBox.X2 }} {{ $paragraph.BBox.Y2 }}'>
+            {{- range $lineIndex, $line := $paragraph.Lines }}
+            <span class='{{ $line.Class }}' id='{{ $line.ID }}'{{ if $line.Lang }} lang='{{ $line.Lang }}'{{ end }} title='bbox {{ $line.BBox.X1 }} {{ $line.BBox.Y1 }} {{ $line.BBox.X2 }} {{ $line.BBox.Y2 }}{{ if $line.Baseline }}; baseline {{ $line.Baseline }}{{ end }}'>{{ range $wordIndex, $word := $line.Words }}<span class='{{ $word.Class }}' id='{{ $word.ID }}'{{ if $word.Lang }} lang='{{ $word.Lang }}'{{ end }} title='bbox {{ $word.BBox.X1 }} {{ $word.BBox.Y1 }} {{ $word.BBox.X2 }} {{ $word.BBox.Y2 }}{{ if ne $word.Confidence 0.0 }}; x_wconf {{ printf "%.0f" $word.Confidence }}{{ end }}'>{{ $word.Text }}</span>{{ end }}</span>
+            {{- end }}
+            
+            {{- if $paragraph.Words }}
+            <!-- Direct words in paragraph (if no lines) -->
+            {{- range $wordIndex, $word := $paragraph.Words }}
+            <span class='{{ $word.Class }}' id='{{ $word.ID }}'{{ if $word.Lang }} lang='{{ $word.Lang }}'{{ end }} title='bbox {{ $word.BBox.X1 }} {{ $word.BBox.Y1 }} {{ $word.BBox.X2 }} {{ $word.BBox.Y2 }}{{ if ne $word.Confidence 0.0 }}; x_wconf {{ printf "%.0f" $word.Confidence }}{{ end }}'>{{ $word.Text }}</span>
+            {{- end }}
+            {{- end }}
+        </p>
+        {{- end }}
+        
+        {{- if $page.Lines }}
+        <!-- Direct lines in page (if no areas, blocks, or paragraphs) -->
+        {{- range $lineIndex, $line := $page.Lines }}
+        <span class='{{ $line.Class }}' id='{{ $line.ID }}'{{ if $line.Lang }} lang='{{ $line.Lang }}'{{ end }} title='bbox {{ $line.BBox.X1 }} {{ $line.BBox.Y1 }} {{ $line.BBox.X2 }} {{ $line.BBox.Y2 }}{{ if $line.Baseline }}; baseline {{ $line.Baseline }}{{ end }}'>{{ range $wordIndex, $word := $line.Words }}<span class='{{ $word.Class }}' id='{{ $word.ID }}'{{ if $word.Lang }} lang='{{ $word.Lang }}'{{ end }} title='bbox {{ $word.BBox.X1 }} {{ $word.BBox.Y1 }} {{ $word.BBox.X2 }} {{ $word.BBox.Y2 }}{{ if ne $word.Confidence 0.0 }}; x_wconf {{ printf "%.0f" $word.Confidence }}{{ end }}'>{{ $word.Text }}</span>{{ end }}</span>
+        {{- end }}
+        {{- end }}
+    </div>
+    {{- end }}
+</body>
+</html>

--- a/pkg/hocr/types.go
+++ b/pkg/hocr/types.go
@@ -1,0 +1,107 @@
+package hocr
+
+// HOCR represents the entire hOCR document structure
+type HOCR struct {
+	Title       string            // Document title
+	Description string            // Document description
+	Language    string            // Document language
+	Metadata    map[string]string // Additional metadata
+	Pages       []Page            // Pages in the document
+}
+
+// Page is one page of recognized text
+// Corresponds to hOCR element with class: 'ocr_page'
+type Page struct {
+	ID         string            // Unique identifier
+	Title      string            // Original title attribute
+	PageNumber int               // Page number in document
+	ImageName  string            // Source image filename
+	Lang       string            // Language code for this page
+	BBox       BoundingBox       // Page coordinates
+	Areas      []Area            // Content areas (columns)
+	Paragraphs []Paragraph       // Paragraphs directly under page
+	Lines      []Line            // Lines directly under page (no parent)
+	Metadata   map[string]string // Other page properties
+}
+
+// Class assign 'ocr_page' to 'Page' struct
+func (Page) Class() string { return "ocr_page" }
+
+// Area represents a content area (column or region)
+// Corresponds to hOCR element with class: 'ocr_carea'
+type Area struct {
+	ID         string            // Unique identifier
+	Lang       string            // Language code
+	BBox       BoundingBox       // Area coordinates
+	Paragraphs []Paragraph       // Paragraphs in this area
+	Lines      []Line            // Text lines directly under area
+	Words      []Word            // Words directly under area (no line parent)
+	Metadata   map[string]string // Other area properties
+}
+
+// Class assign 'ocr_carea' to 'Area' struct
+func (Area) Class() string { return "ocr_carea" }
+
+// Paragraph represents a paragraph within an area or block
+// Corresponds to hOCR element with class: 'ocr_par'
+type Paragraph struct {
+	ID       string            // Unique identifier
+	Lang     string            // Language code
+	BBox     BoundingBox       // Paragraph coordinates
+	Lines    []Line            // Text lines in this paragraph
+	Words    []Word            // Words directly under paragraph (no line parent)
+	Metadata map[string]string // Other paragraph properties
+}
+
+// Class assign 'ocr_par' to 'Paragraph' struct
+func (Paragraph) Class() string { return "ocr_par" }
+
+// Line represents a line of text
+// Corresponds to hOCR element with class: 'ocr_line'
+type Line struct {
+	ID       string            // Unique identifier
+	Lang     string            // Language code
+	BBox     BoundingBox       // Line coordinates
+	Baseline string            // Baseline information
+	Words    []Word            // Words in this line
+	Metadata map[string]string // Other line properties
+}
+
+// Class assign 'ocr_line' to 'Line' struct
+func (Line) Class() string { return "ocr_line" }
+
+// Word is a recognized word with bounding box
+// Corresponds to hOCR element with class: 'ocrx_word'
+type Word struct {
+	ID         string            // Unique identifier
+	Text       string            // The actual text content
+	BBox       BoundingBox       // Word coordinates
+	Confidence float64           // Recognition confidence (0-100)
+	Lang       string            // Language code
+	Metadata   map[string]string // Other word properties
+}
+
+// Class assign 'ocrx_word' to 'Word' struct
+func (Word) Class() string { return "ocrx_word" }
+
+// BoundingBox represents a rectangle in the document
+// Used to store hOCR 'bbox' property values
+type BoundingBox struct {
+	X1 float64 // Left coordinate
+	Y1 float64 // Top coordinate
+	X2 float64 // Right coordinate
+	Y2 float64 // Bottom coordinate
+}
+
+// NewBoundingBox creates a bounding box from coordinates
+// This is a convenience constructor function that creates a bounding box
+// from the x1, y1, x2, y2 coordinates commonly found in hOCR 'bbox' properties.
+// x1, y1 represent the top-left corner, while x2, y2 represent the bottom-right corner.
+func NewBoundingBox(x1, y1, x2, y2 float64) BoundingBox {
+	return BoundingBox{
+		X1: x1,
+		Y1: y1,
+		X2: x2,
+		Y2: y2,
+	}
+}


### PR DESCRIPTION
This package provides:

- A complete object model representing the hOCR hierarchy
- Functions for parsing hOCR HTML into structured Go types
- Functions for generating valid hOCR HTML from Go structures
- Utilities for working with bounding boxes and positional data

The package implements the hierarchical structure defined in the hOCR format:
Document → Pages → Areas → Paragraphs → Lines → Words, with metadata at each level.

Key Types:

- HOCR: Top-level structure representing an entire hOCR document
- Page: Represents a single page with class 'ocr_page'
- Area: Represents a content area with class 'ocr_carea'
- Paragraph: Represents a paragraph with class 'ocr_par'
- Line: Represents a line of text with class 'ocr_line'
- Word: Represents a single word with class 'ocrx_word'
- BoundingBox: Represents a rectangle with coordinates for positioning elements

Main Functions:

- ParseHOCR: Parses hOCR data from HTML into the object model
- GenerateHOCRDocument: Generates valid hOCR HTML from the object model