### PR TITLE
feat(pdfocr): add a package/cli for adding OCR text layers to PDFs

### DIFF
--- a/cmd/pdfocr/main.go
+++ b/cmd/pdfocr/main.go
@@ -1,0 +1,151 @@
+// pdfocr is a command-line tool for creating searchable PDFs with OCR text layers.
+//
+// This tool can either enhance existing PDFs with OCR text layers or create new PDFs
+// from images with embedded OCR text. It uses HOCR data to position text accurately within
+// the document at the exact position of each recognized word.
+//
+// Usage:
+//
+//	pdfocr -hocr document.hocr [options]
+//
+// Required flags:
+//
+//	-hocr string      Path to HOCR file
+//	-output string    Output PDF path
+//
+// Input options (one required):
+//
+//	-pdf string       Path to existing PDF to enhance with OCR
+//	-image-dir string Directory containing page images to build a new PDF
+//
+// Processing options:
+//
+//	-start-page int   Start applying OCR from this page (default 1)
+//	-debug            Enable debug mode (shows OCR bounding boxes)
+//	-force            Force reapply OCR even if layer exists
+//	-overwrite        Overwrite output file if it exists
+//	-debug-pdf        Dump PDF structure for debugging
+//
+// Examples:
+//
+// Add OCR layer to existing PDF:
+//
+//	pdfocr -hocr document.hocr -pdf document.pdf -output document_searchable.pdf
+//
+// Create PDF from image directory with OCR:
+//
+//	pdfocr -hocr document.hocr -image-dir ./page_images -output document_searchable.pdf
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/gardar/ocrchestra/pkg/pdfocr"
+)
+
+func main() {
+	hocrPath := flag.String("hocr", "", "Path to a multi-page HOCR file")
+	imageDirPath := flag.String("image-dir", "", "Directory containing images")
+	pdfPath := flag.String("pdf", "", "Path to an existing PDF to add OCR layer to")
+	pdfOcrPath := flag.String("output", "", "Output PDF path")
+	startPage := flag.Int("start-page", 1, "Start applying OCR from this page number (1-based index)")
+	debug := flag.Bool("debug", false, "Enable debug mode")
+	force := flag.Bool("force", false, "Force reapply OCR even if an OCR layer is already detected")
+	overwriteOutput := flag.Bool("overwrite", false, "Overwrite the output PDF if it already exists")
+	dumpPDF := flag.Bool("debug-pdf", false, "Dump PDF structure for debugging")
+	flag.Parse()
+
+	if *hocrPath == "" {
+		fmt.Println("Error: Must provide -hocr path")
+		os.Exit(1)
+	}
+	if *imageDirPath == "" && *pdfPath == "" {
+		fmt.Println("Error: Must provide either -image-dir or -input-pdf")
+		os.Exit(1)
+	}
+
+	if _, err := os.Stat(*pdfOcrPath); err == nil {
+		if !*overwriteOutput {
+			fmt.Printf("Output file %s already exists. Use -overwrite to overwrite.\n", *pdfOcrPath)
+			os.Exit(1)
+		}
+		os.Remove(*pdfOcrPath)
+	}
+
+	// Build the OCRConfig
+	config := pdfocr.OCRConfig{
+		Debug:     *debug,
+		Force:     *force,
+		StartPage: *startPage,
+		DumpPDF:   *dumpPDF,
+		Font:      pdfocr.DefaultFont,
+	}
+
+	// Read and parse hOCR
+	hOCR, err := os.ReadFile(*hocrPath)
+	if err != nil {
+		fmt.Printf("Failed to read HOCR file: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Either create a new PDF from images or modify an existing PDF
+	var finalPDF []byte
+	if *imageDirPath != "" {
+		// Create new PDF from images
+		imagePaths, err := filepath.Glob(filepath.Join(*imageDirPath, "*"))
+		if err != nil {
+			fmt.Printf("Error accessing image directory: %v\n", err)
+			os.Exit(1)
+		}
+		sort.Strings(imagePaths)
+		fmt.Printf("Found %d image files in %s\n", len(imagePaths), *imageDirPath)
+
+		// Read all images into memory
+		var imagesData [][]byte
+		for _, imgPath := range imagePaths {
+			imgBytes, err := os.ReadFile(imgPath)
+			if err != nil {
+				fmt.Printf("Failed to read image %s: %v\n", imgPath, err)
+				os.Exit(1)
+			}
+			imagesData = append(imagesData, imgBytes)
+		}
+
+		// Assemble the OCR'd PDF
+		finalPDF, err = pdfocr.AssembleWithOCR(hOCR, imagesData, config)
+		if err != nil {
+			fmt.Printf("Error creating PDF from images: %v\n", err)
+			os.Exit(1)
+		}
+
+	} else {
+		// Modify an existing PDF
+		inputData, err := os.ReadFile(*pdfPath)
+		if err != nil {
+			fmt.Printf("Failed to read input PDF: %v\n", err)
+			os.Exit(1)
+		}
+
+		// Apply the OCR layer to the PDF
+		finalPDF, err = pdfocr.ApplyOCR(inputData, hOCR, config)
+		if err != nil {
+			fmt.Printf("Error applying OCR to existing PDF: %v\n", err)
+			os.Exit(1)
+		}
+	}
+
+	if *imageDirPath != "" && *force {
+		fmt.Println("Warning: -force is only applicable when -pdf is set. Ignoring -force.")
+	}
+
+	// Write final PDF to disk
+	if err := os.WriteFile(*pdfOcrPath, finalPDF, 0666); err != nil {
+		fmt.Printf("Failed to write output PDF: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println("✅ OCR-enhanced PDF created:", *pdfOcrPath)
+}

--- a/pkg/pdfocr/config.go
+++ b/pkg/pdfocr/config.go
@@ -1,0 +1,47 @@
+package pdfocr
+
+import (
+	"io"
+)
+
+// OCRConfig holds user options for applying OCR to PDF
+type OCRConfig struct {
+	Debug       bool      // Enable debug mode
+	Force       bool      // Force reapply OCR even if layer already exists
+	LayerName   string    // Base name of OCR layer (page number will be appended)
+	StartPage   int       // Start applying OCR from this page number
+	DumpPDF     bool      // Dump PDF structure for debugging
+	LogWarnings bool      // Whether to print warnings
+	Logger      io.Writer // Custom logger for warnings (nil = stdout)
+	Font        FontConfig
+}
+
+// DefaultConfig returns a config with sensible defaults
+func DefaultConfig() OCRConfig {
+	return OCRConfig{
+		Debug:       false,
+		Force:       false,
+		LayerName:   "OCR Text", // Will be formatted as "OCR Text (Page X)" in the final PDF
+		StartPage:   1,
+		DumpPDF:     false,
+		LogWarnings: true,
+		Logger:      nil, // stdout
+		Font:        DefaultFont,
+	}
+}
+
+// FontConfig contains font settings for OCR text rendering
+type FontConfig struct {
+	Name        string  // Font name (e.g., "Helvetica")
+	Style       string  // Font style ("", "B", "I", "BI")
+	Size        float64 // Default font size
+	AscentRatio float64 // Vertical positioning ratio
+}
+
+// DefaultFont sets the default font to Helvetica which is tried and tested for the OCR layer
+var DefaultFont = FontConfig{
+	Name:        "Helvetica",
+	Style:       "",
+	Size:        10,
+	AscentRatio: 0.718,
+}

--- a/pkg/pdfocr/create.go
+++ b/pkg/pdfocr/create.go
@@ -1,0 +1,74 @@
+package pdfocr
+
+import (
+	"bytes"
+	"codeberg.org/go-pdf/fpdf"
+	"fmt"
+	"github.com/gardar/ocrchestra/pkg/hocr"
+	"image"
+	"strings"
+)
+
+// createPDFFromImage builds a new PDF from images with their corresponding OCR data.
+// This function assumes inputs have been validated by the caller.
+func createPDFFromImage(
+	hOCRData hocr.HOCR,
+	imagesData [][]byte,
+	startFromPage int,
+	debug bool,
+	layerName string,
+	fontConfig FontConfig,
+) ([]byte, error) {
+	startIdx := startFromPage - 1
+	pdf := fpdf.New("P", "pt", "A4", "")
+
+	for i := startIdx; i < len(hOCRData.Pages) && i < len(imagesData); i++ {
+		page := hOCRData.Pages[i]
+		w, h := page.BBox.X2, page.BBox.Y2
+
+		// Calculate the actual page number (1-based, accounting for startFromPage)
+		actualPageNum := i + 1 // 1-based page number in the resulting PDF
+
+		// Add page with appropriate dimensions
+		pdf.AddPageFormat("P", fpdf.SizeType{Wd: w, Ht: h})
+
+		// Add image to page
+		imageName := fmt.Sprintf("img%d", i)
+		imageType, err := detectImageType(imagesData[i])
+		if err != nil {
+			// This should rarely happen since validation should be done at the higher level
+			return nil, fmt.Errorf("failed to detect image type for image %d: %w", i, err)
+		}
+
+		opts := fpdf.ImageOptions{ReadDpi: false, ImageType: imageType}
+		pdf.RegisterImageOptionsReader(imageName, opts, bytes.NewReader(imagesData[i]))
+		pdf.ImageOptions(imageName, 0, 0, w, h, false, opts, 0, "")
+
+		// Create transformation function for this page
+		transform := func(x, y float64) (float64, float64) {
+			return normalizeCoords(x, y, w, h, w, h)
+		}
+
+		// Add OCR layer with page number
+		err = drawOCRLayer(pdf, page, debug, layerName, actualPageNum, transform, fontConfig)
+		if err != nil {
+			return nil, fmt.Errorf("failed to draw OCR layer for page %d: %w", i+1, err)
+		}
+	}
+
+	// Generate final PDF
+	var buf bytes.Buffer
+	if err := pdf.Output(&buf); err != nil {
+		return nil, fmt.Errorf("failed to generate PDF: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+// detectImageType tries to figure out whether the data is PNG, JPEG, etc.
+func detectImageType(data []byte) (string, error) {
+	_, format, err := image.DecodeConfig(bytes.NewReader(data))
+	if err != nil {
+		return "", fmt.Errorf("failed to decode image config: %w", err)
+	}
+	return strings.ToUpper(format), nil
+}

--- a/pkg/pdfocr/detect.go
+++ b/pkg/pdfocr/detect.go
@@ -1,0 +1,113 @@
+package pdfocr
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// detectPDFLayers attempts to find layer names in the raw PDF data.
+func detectPDFLayers(pdfData []byte) ([]string, error) {
+	if len(pdfData) == 0 {
+		return nil, fmt.Errorf("empty PDF data")
+	}
+
+	content := string(pdfData)
+	ocgPatterns := []string{
+		`/Type\s*/OCG\s*/Name\s*\(([^)]+)\)`,
+		`/Title\s*\(([^)]+)\)`,
+		`/OCG\s*<<[^>]*?/Name\s*\(([^)]+)\)`,
+		`<</Type/OCG/Name\(([^)]+)\)`,
+		`/OCProperties.*?/OCGs\s*\[\s*.*?/Name\s*\(([^)]+)\)`,
+		`/Name\s*\(([^)]+)\)[\s\S]{1,50}/Type\s*/OCG`,
+	}
+
+	var layers []string
+	for _, pattern := range ocgPatterns {
+		// Use a panic recovery block for regex operations
+		var regex *regexp.Regexp
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					// Log recovery but continue with other patterns
+					fmt.Printf("Warning: Regex pattern caused error: %v\n", pattern)
+				}
+			}()
+			regex = regexp.MustCompile(pattern)
+		}()
+
+		if regex != nil {
+			matches := regex.FindAllStringSubmatch(content, -1)
+			for _, match := range matches {
+				if len(match) >= 2 {
+					layers = append(layers, unescapePDFString(match[1]))
+				}
+			}
+		}
+	}
+
+	// Check if any are UTF-16 BOM
+	for i, layer := range layers {
+		if len(layer) >= 2 && layer[0] == '\xfe' && layer[1] == '\xff' {
+			decoded, err := decodeUTF16BE([]byte(layer))
+			if err == nil {
+				layers[i] = decoded
+			}
+		}
+	}
+
+	// Deduplicate
+	unique := make([]string, 0, len(layers))
+	seen := make(map[string]bool)
+	for _, l := range layers {
+		if !seen[l] {
+			seen[l] = true
+			unique = append(unique, l)
+		}
+	}
+	return unique, nil
+}
+
+// LayerCheckResult contains the results of checking for OCR layers
+type LayerCheckResult struct {
+	Layers       []string // All detected layers
+	HasOCRLayer  bool     // True if the specified OCR layer exists
+	OCRLayerName string   // Name of the detected OCR layer (if any)
+	Warnings     []string // Any warnings about potential OCR layers
+}
+
+// checkExistingOCRLayers checks for existing OCR layers in a PDF
+func checkExistingOCRLayers(pdfData []byte, ocrLayerName string) (LayerCheckResult, error) {
+	result := LayerCheckResult{}
+
+	// Detect existing layers
+	layers, err := detectPDFLayers(pdfData)
+	if err != nil {
+		return result, fmt.Errorf("cannot analyze layers: %w", err)
+	}
+
+	result.Layers = layers
+
+	// Create a regex to match layer names with page numbers
+	// Pattern will match: "Base Layer Name" or "Base Layer Name (Page X)"
+	pageLayerPattern := regexp.MustCompile(fmt.Sprintf(`^%s(\s*\(Page\s*\d+\))?$`, regexp.QuoteMeta(ocrLayerName)))
+
+	// Check for OCR layers
+	for _, layer := range layers {
+		// Check for exact match or page-specific match
+		if layer == ocrLayerName || pageLayerPattern.MatchString(layer) {
+			result.HasOCRLayer = true
+			result.OCRLayerName = layer
+			break
+		}
+
+		// Check for other potential OCR layers
+		if strings.Contains(strings.ToLower(layer), "ocr") &&
+			!strings.HasPrefix(layer, ocrLayerName) {
+			result.Warnings = append(result.Warnings,
+				fmt.Sprintf("Existing layer detected that might contain OCR: %s", layer))
+		}
+	}
+
+	return result, nil
+}

--- a/pkg/pdfocr/helpers.go
+++ b/pkg/pdfocr/helpers.go
@@ -1,0 +1,77 @@
+package pdfocr
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+// normalizeCoords rescales hOCR Bounding Box (bbox) coords to the PDF coords.
+func normalizeCoords(x, y, hocrW, hocrH, pdfW, pdfH float64) (float64, float64) {
+	nx := (x / hocrW) * pdfW
+	ny := (y / hocrH) * pdfH
+	return nx, ny
+}
+
+func unescapePDFString(s string) string {
+	s = strings.ReplaceAll(s, "\\(", "(")
+	s = strings.ReplaceAll(s, "\\)", ")")
+	s = strings.ReplaceAll(s, "\\\\", "\\")
+	return s
+}
+
+func decodeUTF16BE(b []byte) (string, error) {
+	if len(b) < 2 {
+		return "", fmt.Errorf("input too short for UTF-16BE")
+	}
+	hasBOM := false
+	if b[0] == 0xFE && b[1] == 0xFF {
+		hasBOM = true
+		b = b[2:]
+	}
+	if !hasBOM {
+		return "", fmt.Errorf("no BOM detected, cannot confirm UTF-16BE")
+	}
+	var runes []rune
+	for i := 0; i < len(b); i += 2 {
+		if i+1 >= len(b) {
+			break
+		}
+		charCode := uint16(b[i])<<8 | uint16(b[i+1])
+		runes = append(runes, rune(charCode))
+	}
+	return string(runes), nil
+}
+
+// dumpPDFStructure is a debug utility that prints out
+// the first N bytes of the PDF plus any /OCG layer references.
+func dumpPDFStructure(pdfData []byte, byteCount int, logger io.Writer) {
+	if logger == nil {
+		logger = os.Stdout // Default to stdout
+	}
+
+	if byteCount > len(pdfData) {
+		byteCount = len(pdfData)
+	}
+
+	fmt.Fprintln(logger, "===== PDF STRUCTURE DUMP (FIRST", byteCount, "BYTES) =====")
+	fmt.Fprintln(logger, string(pdfData[:byteCount]))
+	fmt.Fprintln(logger, "===== END PDF STRUCTURE DUMP =====")
+
+	ocgIndex := bytes.Index(pdfData, []byte("/OCG"))
+	if ocgIndex >= 0 {
+		start := ocgIndex - 20
+		if start < 0 {
+			start = 0
+		}
+		end := ocgIndex + 100
+		if end > len(pdfData) {
+			end = len(pdfData)
+		}
+		fmt.Fprintln(logger, "===== OCG CONTEXT =====")
+		fmt.Fprintln(logger, string(pdfData[start:end]))
+		fmt.Fprintln(logger, "===== END OCG CONTEXT =====")
+	}
+}

--- a/pkg/pdfocr/layer.go
+++ b/pkg/pdfocr/layer.go
@@ -1,0 +1,144 @@
+package pdfocr
+
+import (
+	"fmt"
+
+	"codeberg.org/go-pdf/fpdf"
+	"golang.org/x/text/encoding/charmap"
+
+	"github.com/gardar/ocrchestra/pkg/hocr"
+)
+
+// drawOCRLayer draws the OCR text onto a layer in a pdf page.
+// The pageNum parameter is used to create unique layer names for each page.
+func drawOCRLayer(
+	pdf *fpdf.Fpdf,
+	page hocr.Page,
+	debug bool,
+	layerName string,
+	pageNum int,
+	transform func(x, y float64) (float64, float64),
+	fontConfig FontConfig,
+) error {
+	// Format layer name with page number if not already included
+	formattedLayerName := layerName
+	if pageNum > 0 {
+		formattedLayerName = fmt.Sprintf("%s (Page %d)", layerName, pageNum)
+	}
+
+	layer := pdf.AddLayer(formattedLayerName, true)
+	pdf.BeginLayer(layer)
+	pdf.SetFont(fontConfig.Name, fontConfig.Style, fontConfig.Size)
+
+	if debug {
+		pdf.SetTextColor(255, 0, 0) // highlight text in red
+	} else {
+		pdf.SetAlpha(0.0, "Normal") // hide text from normal view
+	}
+
+	encodingErrors := 0
+	wordCount := 0
+
+	// Process words from areas
+	for _, area := range page.Areas {
+		// Words directly under area
+		for _, word := range area.Words {
+			drawWord(pdf, word, transform, fontConfig, debug, &encodingErrors)
+			wordCount++
+		}
+
+		// Words in lines under area
+		for _, line := range area.Lines {
+			for _, word := range line.Words {
+				drawWord(pdf, word, transform, fontConfig, debug, &encodingErrors)
+				wordCount++
+			}
+		}
+
+		// Process words from paragraphs under area
+		for _, paragraph := range area.Paragraphs {
+			// Words directly under paragraph
+			for _, word := range paragraph.Words {
+				drawWord(pdf, word, transform, fontConfig, debug, &encodingErrors)
+				wordCount++
+			}
+
+			// Words in lines under paragraph
+			for _, line := range paragraph.Lines {
+				for _, word := range line.Words {
+					drawWord(pdf, word, transform, fontConfig, debug, &encodingErrors)
+					wordCount++
+				}
+			}
+		}
+	}
+
+	// Process words from paragraphs directly under page
+	for _, paragraph := range page.Paragraphs {
+		// Words directly under paragraph
+		for _, word := range paragraph.Words {
+			drawWord(pdf, word, transform, fontConfig, debug, &encodingErrors)
+			wordCount++
+		}
+
+		// Words in lines under paragraph
+		for _, line := range paragraph.Lines {
+			for _, word := range line.Words {
+				drawWord(pdf, word, transform, fontConfig, debug, &encodingErrors)
+				wordCount++
+			}
+		}
+	}
+
+	// Process words from lines directly under page
+	for _, line := range page.Lines {
+		for _, word := range line.Words {
+			drawWord(pdf, word, transform, fontConfig, debug, &encodingErrors)
+			wordCount++
+		}
+	}
+
+	pdf.EndLayer()
+
+	// Report encoding errors if more than a threshold
+	if wordCount > 0 && encodingErrors > 0 && encodingErrors > wordCount/10 {
+		return fmt.Errorf("character encoding issues in %d of %d words",
+			encodingErrors, wordCount)
+	}
+
+	return nil
+}
+
+// drawWord renders a single word onto the PDF layer
+func drawWord(pdf *fpdf.Fpdf, word hocr.Word, transform func(x, y float64) (float64, float64),
+	fontConfig FontConfig, debug bool, encodingErrors *int) {
+
+	x, y := transform(word.BBox.X1, word.BBox.Y1)
+	x2, _ := transform(word.BBox.X2, word.BBox.Y1)
+	wordWidth := x2 - x
+
+	// Convert text to ISO-8859-1 to avoid PDF encoding issues
+	latin1, err := charmap.ISO8859_1.NewEncoder().String(word.Text)
+	if err != nil {
+		// Track encoding errors but continue
+		*encodingErrors++
+		latin1 = word.Text // fallback to raw text
+	}
+
+	strWidth := pdf.GetStringWidth(latin1)
+	if strWidth > 0 {
+		scale := wordWidth / strWidth
+		pdf.SetFontSize(fontConfig.Size * scale)
+	}
+
+	fontSize, _ := pdf.GetFontSize()
+	y += fontSize * fontConfig.AscentRatio
+
+	pdf.Text(x, y, latin1)
+	pdf.SetFontSize(fontConfig.Size)
+
+	if debug {
+		height := word.BBox.Y2 - word.BBox.Y1
+		pdf.Rect(x, y-(fontSize*fontConfig.AscentRatio), wordWidth, height, "D")
+	}
+}

--- a/pkg/pdfocr/modify.go
+++ b/pkg/pdfocr/modify.go
@@ -1,0 +1,51 @@
+package pdfocr
+
+import (
+	"bytes"
+	"io"
+
+	"codeberg.org/go-pdf/fpdf"
+	"codeberg.org/go-pdf/fpdf/contrib/gofpdi"
+
+	"github.com/gardar/ocrchestra/pkg/hocr"
+)
+
+// modifyExistingPDF imports pages from an existing PDF and overlays OCR text layer.
+func modifyExistingPDF(
+	inputPDFData []byte,
+	hOCRData hocr.HOCR,
+	startFromPage int,
+	debug bool,
+	layerName string,
+	fontConfig FontConfig,
+) ([]byte, error) {
+
+	pdf := fpdf.New("P", "pt", "", "")
+	importer := gofpdi.NewImporter()
+	rs := io.ReadSeeker(bytes.NewReader(inputPDFData))
+
+	for i, page := range hOCRData.Pages {
+		targetPage := i + startFromPage
+
+		// Calculate the actual page number in the PDF
+		actualPageNum := i + 1 // 1-based page number in the resulting PDF
+
+		pdf.AddPageFormat("P", fpdf.SizeType{Wd: page.BBox.X2, Ht: page.BBox.Y2})
+
+		tpl := importer.ImportPageFromStream(pdf, &rs, targetPage, "/MediaBox")
+		importer.UseImportedTemplate(pdf, tpl, 0, 0, page.BBox.X2, 0)
+
+		identity := func(x, y float64) (float64, float64) {
+			return x, y
+		}
+
+		// Pass the page number to drawOCRLayer
+		drawOCRLayer(pdf, page, debug, layerName, actualPageNum, identity, fontConfig)
+	}
+
+	var buf bytes.Buffer
+	if err := pdf.Output(&buf); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}

--- a/pkg/pdfocr/pdfocr.go
+++ b/pkg/pdfocr/pdfocr.go
@@ -1,0 +1,196 @@
+// Package pdfocr provides functionality for adding OCR text layers from hOCR to PDF documents.
+//
+// This package enables creating OCR enhanced searchable PDFs either by modifying existing PDFs or
+// by assembling new PDFs from images with an OCR text layer. It works with hOCR data
+// (either raw HTML or parsed structures) to position text accurately within the PDF.
+//
+// Key Features:
+//
+// - Apply OCR text layers to existing PDFs, making them searchable and text selectable
+// - Create new PDFs from images with OCR text layers
+// - Detect existing OCR layers to prevent duplication
+//
+// Main Functions:
+//
+// - ApplyOCR: Adds OCR text layer to an existing PDF
+// - AssembleWithOCR: Creates a new PDF from images with OCR text layer
+//
+package pdfocr
+
+import (
+	"fmt"
+
+	"github.com/gardar/ocrchestra/pkg/hocr"
+)
+
+// AssembleWithOCR is a high-level function for creating a PDF from images
+// and applying the HOCR text overlay.
+// It accepts either raw HOCR data ([]byte) or a parsed HOCR struct (*hocr.HOCR).
+func AssembleWithOCR(
+	hocrInput interface{},
+	imagesData [][]byte,
+	config OCRConfig,
+) ([]byte, error) {
+	// Handle different input types for HOCR
+	var hocrStruct hocr.HOCR
+	var err error
+
+	switch h := hocrInput.(type) {
+	case []byte:
+		// Parse raw HOCR data
+		hocrStruct, err = hocr.ParseHOCR(h)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse HOCR data: %w", err)
+		}
+	case *hocr.HOCR:
+		// Use the provided struct directly
+		if h == nil {
+			return nil, fmt.Errorf("HOCR struct is nil")
+		}
+		hocrStruct = *h
+	default:
+		return nil, fmt.Errorf("unsupported HOCR input type: %T", hocrInput)
+	}
+
+	// Validate inputs
+	if len(hocrStruct.Pages) == 0 {
+		return nil, fmt.Errorf("HOCR data contains no pages")
+	}
+
+	if len(imagesData) == 0 {
+		return nil, fmt.Errorf("no image data provided")
+	}
+	if config.StartPage < 1 {
+		return nil, fmt.Errorf("start page must be at least 1, got %d", config.StartPage)
+	}
+
+	// Check if we have enough images for hOCR pages
+	if len(imagesData) < len(hocrStruct.Pages) {
+		return nil, fmt.Errorf("not enough images (%d) for HOCR pages (%d)",
+			len(imagesData), len(hocrStruct.Pages))
+	}
+
+	// Validate image formats
+	for i, imgData := range imagesData {
+		if len(imgData) == 0 {
+			return nil, fmt.Errorf("image %d is empty", i+1)
+		}
+		imageType, err := detectImageType(imgData)
+		if err != nil {
+			return nil, fmt.Errorf("image %d has invalid format: %w", i+1, err)
+		}
+		if config.Debug {
+			fmt.Printf("Image %d is of type: %s\n", i+1, imageType)
+		}
+	}
+
+	// Build the PDF from images
+	finalPDF, err := createPDFFromImage(
+		hocrStruct,
+		imagesData,
+		config.StartPage,
+		config.Debug,
+		config.LayerName,
+		config.Font,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("error creating PDF from images: %w", err)
+	}
+	return finalPDF, nil
+}
+
+// ApplyOCR is a high-level function for taking an existing PDF and applying hOCR overlays.
+// It performs validation and safety checks.
+// It accepts either raw hOCR data ([]byte) or a parsed hOCR struct (*hocr.HOCR).
+func ApplyOCR(
+	inputPDFData []byte,
+	hocrInput interface{},
+	config OCRConfig,
+) ([]byte, error) {
+	// Handle different input types for hOCR
+	var hocrStruct hocr.HOCR
+	var err error
+
+	switch h := hocrInput.(type) {
+	case []byte:
+		// Parse raw hOCR data
+		hocrStruct, err = hocr.ParseHOCR(h)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse HOCR data: %w", err)
+		}
+	case *hocr.HOCR:
+		// Use the provided struct directly
+		if h == nil {
+			return nil, fmt.Errorf("HOCR struct is nil")
+		}
+		hocrStruct = *h
+	default:
+		return nil, fmt.Errorf("unsupported HOCR input type: %T", hocrInput)
+	}
+
+	// Validate inputs
+	if len(inputPDFData) == 0 {
+		return nil, fmt.Errorf("input PDF data is empty")
+	}
+	if len(hocrStruct.Pages) == 0 {
+		return nil, fmt.Errorf("HOCR data contains no pages")
+	}
+	if config.StartPage < 1 {
+		return nil, fmt.Errorf("start page must be at least 1, got %d", config.StartPage)
+	}
+
+	// Display PDF structure debug if requested
+	if config.DumpPDF {
+		dumpPDFStructure(inputPDFData, 2000, config.Logger)
+	}
+
+	// Check for existing layers
+	layerResult, err := checkExistingOCRLayers(inputPDFData, config.LayerName)
+	if err != nil {
+		return nil, fmt.Errorf("layer detection failed: %w", err)
+	}
+
+	// Display layer information if available
+	if len(layerResult.Layers) > 0 {
+		fmt.Println("Existing layers detected in PDF:")
+		for i, layer := range layerResult.Layers {
+			fmt.Printf("  %d. %s\n", i+1, layer)
+		}
+
+		// Additional debug information if requested
+		if config.Debug {
+			fmt.Println("Debug: Raw layer names with byte representation:")
+			for i, layer := range layerResult.Layers {
+				fmt.Printf("  %d. %q\n", i+1, layer)
+			}
+		}
+	}
+
+	// Report any warnings from layer detection
+	for _, warning := range layerResult.Warnings {
+		fmt.Println("Warning:", warning)
+	}
+
+	// Enforce safety check unless force override is requested
+	if layerResult.HasOCRLayer && !config.Force {
+		return nil, fmt.Errorf("file already has OCR (layer '%s') – use -force to reapply",
+			layerResult.OCRLayerName)
+	} else if layerResult.HasOCRLayer {
+		fmt.Println("Warning: file already has OCR; reapplying due to -force will result in duplicate OCR data")
+	}
+
+	// Proceed with PDF modification
+	finalPDF, err := modifyExistingPDF(
+		inputPDFData,
+		hocrStruct,
+		config.StartPage,
+		config.Debug,
+		config.LayerName,
+		config.Font,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("error modifying existing PDF: %w", err)
+	}
+
+	return finalPDF, nil
+}


### PR DESCRIPTION
This package and cli tool can either enhance existing PDFs with OCR text layers or create new PDFs
from images with embedded OCR text. It uses HOCR data to position text accurately within
the document at the exact position of each recognized word.