### PR TITLE
feat(gdocai): add a package/cli for OCR and form extraction using Google Document AI

### DIFF
--- a/cmd/gdocai/main.go
+++ b/cmd/gdocai/main.go
@@ -1,0 +1,376 @@
+// gdocai is a command-line tool for processing documents with Google Document AI and applying the OCR to the documents.
+//
+// This tool extracts text, form fields, and hOCR data from PDFs using Google's Document AI API.
+// It supports applying the OCR text from Google's Document AI to create searchable PDFs and can optionally extract a hOCR document, form field data and text.
+//
+// Configuration:
+//
+// The tool requires a YAML configuration file with Google Document AI settings:
+//
+//	project_id: "your-gcp-project-id"
+//	location: "us"
+//	processor_id: "your-processor-id"
+//
+// Usage:
+//
+//	gdocai -config config.yaml -pdf input.pdf [options]
+//
+// Required flags:
+//
+//	-config string  Path to the YAML configuration file
+//	-pdf string     Path to the input PDF file (required if -pdfs is not defined)
+//	-pdfs string    Comma separated list of input PDF files to process as a single document (required if -pdf is not defined)
+//
+// Output options (at least one required):
+//
+//	-text string        Path to save OCR text output
+//	-hocr string        Path to save HOCR output
+//	-form-fields string Path to save form fields JSON
+//	-images string      Directory to save page images
+//	-output string      Path to save the PDF with OCR applied
+//
+// Debug options:
+//
+//	-debug-api string   Path to save raw API response as JSON
+//	-debug-doc string   Path to save transformed Document object as JSON
+//
+// Authentication:
+//
+// The tool uses the GOOGLE_APPLICATION_CREDENTIALS environment variable
+// for authentication with Google Cloud.
+//
+// Example:
+//
+//	export GOOGLE_APPLICATION_CREDENTIALS=/path/to/credentials.json
+//	gdocai -config config.yaml -pdf document.pdf -text document.txt -hocr document.hocr -output document_ocr.pdf
+//	gdocai -config config.yaml -pdfs page1.pdf,page2.pdf,page3.pdf -output combo_document_ocr.pdf
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/gardar/ocrchestra/pkg/gdocai"
+	"github.com/gardar/ocrchestra/pkg/pdfocr"
+)
+
+type yamlConfig struct {
+	ProjectID   string `yaml:"project_id"`
+	Location    string `yaml:"location"`
+	ProcessorID string `yaml:"processor_id"`
+}
+
+// loadConfig reads a YAML file and converts it to our Google Document AI config
+func loadConfig(path string) (*gdocai.Config, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var yc yamlConfig
+	if err := yaml.Unmarshal(data, &yc); err != nil {
+		return nil, err
+	}
+	return &gdocai.Config{
+		ProjectID:   yc.ProjectID,
+		Location:    yc.Location,
+		ProcessorID: yc.ProcessorID,
+	}, nil
+}
+
+func main() {
+	// Required flags.
+	configPath := flag.String("config", "", "Path to the config YAML file (required)")
+	pdfPath := flag.String("pdf", "", "Path to the input PDF file (required if -pdfs not specified)")
+	pdfPaths := flag.String("pdfs", "", "Comma-separated list of PDF files to process as individual pages (required if -pdf not specified)")
+
+	// Output flags
+	textPath := flag.String("text", "", "Path to save OCR text output")
+	hocrPath := flag.String("hocr", "", "Path to save HOCR output")
+	debugAPIPath := flag.String("debug-api", "", "Path to save API response as JSON for debugging purposes")
+	debugDocPath := flag.String("debug-doc", "", "Path to save transformed Document object as JSON for debugging purposes")
+	formFieldsPath := flag.String("form-fields", "", "Path to save form fields JSON")
+	imagesDir := flag.String("images", "", "Directory to save images returned by Document AI API for each processed page")
+	pdfOcrPath := flag.String("output", "", "Path to save the PDF with OCR applied")
+
+	flag.Parse()
+
+	// Create a map of provided flags to validate
+	providedFlags := make(map[string]bool)
+	flag.Visit(func(f *flag.Flag) {
+		providedFlags[f.Name] = true
+	})
+
+	// Validate that config is provided
+	if *configPath == "" {
+		fmt.Fprintln(os.Stderr, "Error: -config flag is required")
+		fmt.Fprintln(os.Stderr, "Usage:")
+		flag.PrintDefaults()
+		os.Exit(1)
+	}
+
+	// Validate that either pdf or pdfs flag is provided (but not both)
+	if (*pdfPath == "" && *pdfPaths == "") || (*pdfPath != "" && *pdfPaths != "") {
+		fmt.Fprintln(os.Stderr, "Error: Either -pdf or -pdfs flag must be provided (but not both)")
+		fmt.Fprintln(os.Stderr, "Usage:")
+		flag.PrintDefaults()
+		os.Exit(1)
+	}
+
+	// Validate that provided output flags have values
+	hasError := false
+	validateFlag := func(name string, value string) {
+		if providedFlags[name] && value == "" {
+			fmt.Fprintf(os.Stderr, "Error: -%s flag requires a value\n", name)
+			hasError = true
+		}
+	}
+
+	validateFlag("text", *textPath)
+	validateFlag("hocr", *hocrPath)
+	validateFlag("debug-api", *debugAPIPath)
+	validateFlag("debug-doc", *debugDocPath)
+	validateFlag("form-fields", *formFieldsPath)
+	validateFlag("images", *imagesDir)
+	validateFlag("output", *pdfOcrPath)
+
+	if hasError {
+		fmt.Fprintln(os.Stderr, "Usage:")
+		flag.PrintDefaults()
+		os.Exit(1)
+	}
+
+	// Check if at least one output flag is provided
+	hasOutputFlag := providedFlags["text"] || providedFlags["hocr"] ||
+		providedFlags["debug-api"] || providedFlags["debug-doc"] ||
+		providedFlags["form-fields"] || providedFlags["images"] ||
+		providedFlags["output"]
+
+	if !hasOutputFlag {
+		fmt.Fprintln(os.Stderr, "Error: At least one output flag must be provided (-text, -hocr, -debug-api, -debug-doc, -form-fields, -images, or -output)")
+		fmt.Fprintln(os.Stderr, "Usage:")
+		flag.PrintDefaults()
+		os.Exit(1)
+	}
+
+	// Load config from file.
+	cfg, err := loadConfig(*configPath)
+	if err != nil {
+		log.Fatalf("Failed to load config: %v", err)
+	}
+
+	// Process the document based on input flags
+	ctx := context.Background()
+	var doc *gdocai.Document
+	var hocrHTML string
+
+	if *pdfPath != "" {
+		// Process a single PDF file
+		fmt.Println("Processing single PDF file:", *pdfPath)
+
+		// Read PDF bytes from disk.
+		pdfBytes, err := os.ReadFile(*pdfPath)
+		if err != nil {
+			log.Fatalf("Failed to read PDF file: %v", err)
+		}
+
+		// Process the PDF using Google Document AI.
+		doc, hocrHTML, err = gdocai.DocumentHOCR(ctx, pdfBytes, cfg)
+		if err != nil {
+			log.Fatalf("Error processing document: %v", err)
+		}
+	} else {
+		// Process multiple PDF files as individual pages
+		pathsList := strings.Split(*pdfPaths, ",")
+		if len(pathsList) == 0 {
+			log.Fatalf("No PDF files specified with -pdfs")
+		}
+
+		fmt.Printf("Processing %d PDF files as separate pages\n", len(pathsList))
+
+		// Read each PDF file
+		var pdfPageBytes [][]byte
+		for i, path := range pathsList {
+			// Trim any whitespace
+			path = strings.TrimSpace(path)
+			if path == "" {
+				continue
+			}
+
+			fmt.Printf("Reading page %d: %s\n", i+1, path)
+			pageBytes, err := os.ReadFile(path)
+			if err != nil {
+				log.Fatalf("Failed to read PDF file %s: %v", path, err)
+			}
+			pdfPageBytes = append(pdfPageBytes, pageBytes)
+		}
+
+		if len(pdfPageBytes) == 0 {
+			log.Fatalf("No valid PDF files found in the provided list")
+		}
+
+		// Process the PDFs using DocumentHOCRFromPages
+		doc, hocrHTML, err = gdocai.DocumentHOCRFromPages(ctx, pdfPageBytes, cfg)
+		if err != nil {
+			log.Fatalf("Error processing documents: %v", err)
+		}
+	}
+
+	// Write OCR text output if flag is provided.
+	if *textPath != "" {
+		if err := os.WriteFile(*textPath, []byte(doc.Text.Content), 0644); err != nil {
+			log.Fatalf("Failed to write text output: %v", err)
+		}
+		fmt.Println("Document text saved to:", *textPath)
+	}
+
+	// Write hOCR output if flag is provided.
+	if *hocrPath != "" {
+		if err := os.WriteFile(*hocrPath, []byte(hocrHTML), 0644); err != nil {
+			log.Fatalf("Failed to write HOCR output: %v", err)
+		}
+		fmt.Println("Rendered HOCR output saved to:", *hocrPath)
+	}
+
+	// Write API response JSON if flag is provided.
+	if *debugAPIPath != "" {
+		// Note: When using DocumentHOCRFromPages, the Raw.Document field may be nil
+		if doc.Raw != nil && doc.Raw.Document != nil {
+			apiJSON, err := gdocai.ToJSON(doc.Raw.Document)
+			if err != nil {
+				log.Fatalf("Failed to convert API response to JSON: %v", err)
+			}
+			if err := os.WriteFile(*debugAPIPath, []byte(apiJSON), 0644); err != nil {
+				log.Fatalf("Failed to write API response JSON: %v", err)
+			}
+			fmt.Println("API response JSON saved to:", *debugAPIPath)
+		} else {
+			fmt.Println("Warning: Raw API response not available when processing multiple PDF files")
+		}
+	}
+
+	// Write transformed Document JSON if flag is provided.
+	if *debugDocPath != "" {
+		debugJSON, err := gdocai.ToJSON(doc)
+		if err != nil {
+			log.Fatalf("Failed to convert transformed document to JSON: %v", err)
+		}
+		if err := os.WriteFile(*debugDocPath, []byte(debugJSON), 0644); err != nil {
+			log.Fatalf("Failed to write transformed document JSON: %v", err)
+		}
+		fmt.Println("Transformed document JSON saved to:", *debugDocPath)
+	}
+
+	// Write form fields JSON if flag is provided.
+	if *formFieldsPath != "" {
+		formFieldsJSON, err := gdocai.ToJSON(doc.FormFields.Fields)
+		if err != nil {
+			log.Fatalf("Failed to convert form fields to JSON: %v", err)
+		}
+		if err := os.WriteFile(*formFieldsPath, []byte(formFieldsJSON), 0644); err != nil {
+			log.Fatalf("Failed to write form fields JSON: %v", err)
+		}
+		fmt.Println("Form fields JSON saved to:", *formFieldsPath)
+	}
+
+	// Extract and write out images for each page if flag is provided.
+	if *imagesDir != "" {
+		// Ensure output directory exists.
+		if err := os.MkdirAll(*imagesDir, 0755); err != nil {
+			log.Fatalf("Failed to create images directory: %v", err)
+		}
+
+		// Check if we have structured pages to extract images from
+		if doc.Structured != nil && doc.Structured.Pages != nil {
+			// Iterate over each internal page in the document.
+			for i, page := range doc.Structured.Pages {
+				imgBytes, err := gdocai.ExtractImageFromPage(page)
+				if err != nil {
+					log.Printf("Skipping page %d: %v", i+1, err)
+					continue
+				}
+				imagePath := filepath.Join(*imagesDir, fmt.Sprintf("page_%d.png", i+1))
+				if err := os.WriteFile(imagePath, imgBytes, 0644); err != nil {
+					log.Printf("Failed to write image for page %d: %v", i+1, err)
+					continue
+				}
+				fmt.Printf("Saved image for page %d to %s\n", i+1, imagePath)
+			}
+		} else {
+			fmt.Println("Warning: No page images available to extract")
+		}
+	}
+
+	// Generate a new OCR'ed PDF if flag is provided.
+	if *pdfOcrPath != "" {
+		if doc.Hocr != nil && doc.Hocr.Content != nil {
+			var ocrPdfBytes []byte
+			var err error
+
+			if *pdfPath != "" && (*pdfPaths == "" || !providedFlags["pdfs"]) {
+				// Single PDF case - use ApplyOCR to modify the existing PDF
+				fmt.Println("Creating searchable PDF by applying OCR to existing PDF...")
+
+				// Read the original PDF
+				pdfBytes, err := os.ReadFile(*pdfPath)
+				if err != nil {
+					log.Fatalf("Failed to read PDF file: %v", err)
+				}
+
+				// Apply OCR to the PDF
+				ocrPdfBytes, err = pdfocr.ApplyOCR(pdfBytes, doc.Hocr.Content, pdfocr.DefaultConfig())
+				if err != nil {
+					log.Fatalf("Failed to apply OCR to PDF: %v", err)
+				}
+			} else {
+				// Multiple PDFs case - create a new PDF from page images
+				fmt.Println("Creating new searchable PDF from Document AI page images...")
+
+				// Get images from Document AI results (in memory only)
+				var pageImages [][]byte
+
+				if doc.Structured != nil && doc.Structured.Pages != nil {
+					for i, page := range doc.Structured.Pages {
+						imgBytes, err := gdocai.ExtractImageFromPage(page)
+						if err != nil {
+							log.Fatalf("Failed to get image data for page %d: %v", i+1, err)
+						}
+						pageImages = append(pageImages, imgBytes)
+						fmt.Printf("Using image data for page %d (%d bytes)\n", i+1, len(imgBytes))
+					}
+				} else {
+					log.Fatalf("No page image data available in the document structure")
+				}
+
+				// Verify we have images for all pages
+				if len(pageImages) == 0 {
+					log.Fatalf("No page image data was found")
+				}
+
+				fmt.Printf("Assembling PDF with %d pages...\n", len(pageImages))
+
+				// Use AssembleWithOCR to create a new PDF from images
+				ocrConfig := pdfocr.DefaultConfig()
+				ocrPdfBytes, err = pdfocr.AssembleWithOCR(doc.Hocr.Content, pageImages, ocrConfig)
+				if err != nil {
+					log.Fatalf("Failed to create PDF from images: %v", err)
+				}
+			}
+
+			// Write the final PDF
+			if err := os.WriteFile(*pdfOcrPath, ocrPdfBytes, 0644); err != nil {
+				log.Fatalf("Failed to write OCR'ed PDF: %v", err)
+			}
+			fmt.Println("OCR'ed PDF saved to:", *pdfOcrPath)
+		} else {
+			log.Fatalf("HOCR content not available for creating searchable PDF")
+		}
+	}
+}

--- a/pkg/gdocai/client.go
+++ b/pkg/gdocai/client.go
@@ -1,0 +1,50 @@
+package gdocai
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	documentai "cloud.google.com/go/documentai/apiv1"
+	"cloud.google.com/go/documentai/apiv1/documentaipb"
+	"google.golang.org/api/option"
+)
+
+// ProcessDocument sends PDF bytes to Google Document AI for processing
+// and returns the raw Document proto response
+func ProcessDocument(ctx context.Context, pdfBytes []byte, cfg *Config) (*documentaipb.Document, error) {
+	// Instantiate Document AI client using credentials from environment variable
+	client, err := documentai.NewDocumentProcessorClient(
+		ctx,
+		option.WithCredentialsFile(os.Getenv("GOOGLE_APPLICATION_CREDENTIALS")),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Document AI client: %w", err)
+	}
+	defer client.Close()
+
+	// Build the resource name of the processor
+	name := fmt.Sprintf(
+		"projects/%s/locations/%s/processors/%s",
+		cfg.ProjectID, cfg.Location, cfg.ProcessorID,
+	)
+
+	// Create the request
+	req := &documentaipb.ProcessRequest{
+		Name: name,
+		Source: &documentaipb.ProcessRequest_RawDocument{
+			RawDocument: &documentaipb.RawDocument{
+				Content:  pdfBytes,
+				MimeType: "application/pdf",
+			},
+		},
+		SkipHumanReview: true,
+	}
+
+	resp, err := client.ProcessDocument(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to process document: %w", err)
+	}
+
+	return resp.Document, nil
+}

--- a/pkg/gdocai/config.go
+++ b/pkg/gdocai/config.go
@@ -1,0 +1,8 @@
+package gdocai
+
+// Config holds the settings needed for Google Document AI
+type Config struct {
+	ProjectID   string
+	Location    string
+	ProcessorID string
+}

--- a/pkg/gdocai/document.go
+++ b/pkg/gdocai/document.go
@@ -1,0 +1,239 @@
+package gdocai
+
+import (
+	"sort"
+
+	"cloud.google.com/go/documentai/apiv1/documentaipb"
+	"github.com/gardar/ocrchestra/pkg/hocr"
+)
+
+// DocumentFromProto converts a Document AI response into our structure
+func DocumentFromProto(doc *documentaipb.Document) *Document {
+	// Extract the text content
+	text := textFromProto(doc)
+
+	// Extract form fields
+	formFields := ExtractFormFields(doc)
+
+	// Create the structured document with pages
+	structuredDoc := &StructuredDocument{
+		Pages: createPagesFromProtoDoc(doc),
+	}
+
+	// Create the wrapper for the raw document
+	rawDoc := &RawDocument{
+		Document: doc,
+	}
+
+	// Create form data wrapper
+	formData := &FormData{
+		Fields: formFields,
+	}
+
+	// Create text content wrapper
+	textContent := &TextContent{
+		Content: text,
+	}
+
+	// Create HOCR content
+	hocrStruct, _ := CreateHOCRStruct(doc)
+	generatedHTML, _ := hocr.GenerateHOCRDocument(hocrStruct)
+
+	hocrContent := &HocrContent{
+		Content: hocrStruct,
+		HTML:    generatedHTML,
+	}
+
+	// Assemble the full document
+	return &Document{
+		Raw:        rawDoc,
+		Structured: structuredDoc,
+		Text:       textContent,
+		Hocr:       hocrContent,
+		FormFields: formData,
+	}
+}
+
+// createPagesFromProtoDoc transforms the raw Document AI pages into structured format
+// This builds the hierarchy of blocks, paragraphs, lines and tokens
+func createPagesFromProtoDoc(doc *documentaipb.Document) []*Page {
+	var result []*Page
+
+	// Process each page in the document
+	for _, page := range doc.Pages {
+		pageNum := int(page.PageNumber)
+		docAiPage := &Page{
+			DocumentaiObject: page,
+			DocumentText:     doc.Text,
+			PageNumber:       pageNum,
+			Text:             textFromLayout(page.Layout, doc.Text),
+		}
+
+		// Collect form fields
+		docAiPage.FormFields = make([]*FormField, 0, len(page.FormFields))
+		for _, formField := range page.FormFields {
+			docAiPage.FormFields = append(docAiPage.FormFields, &FormField{
+				DocumentaiObject: formField,
+				DocumentText:     doc.Text,
+				FieldName:        textFromLayout(formField.FieldName, doc.Text),
+				FieldValue:       textFromLayout(formField.FieldValue, doc.Text),
+			})
+		}
+
+		// Collect tokens (words)
+		docAiPage.Tokens = make([]*Token, 0, len(page.Tokens))
+		for _, token := range page.Tokens {
+			txt := textFromLayout(token.Layout, doc.Text)
+			// Trim trailing whitespace if the token has a detected break
+			if token.DetectedBreak != nil &&
+				token.DetectedBreak.Type != documentaipb.Document_Page_Token_DetectedBreak_TYPE_UNSPECIFIED {
+				runesTok := []rune(txt)
+				if len(runesTok) > 0 {
+					last := runesTok[len(runesTok)-1]
+					if last == ' ' || last == '\n' || last == '\r' || last == '\t' {
+						txt = string(runesTok[:len(runesTok)-1])
+					}
+				}
+			}
+
+			docAiToken := &Token{
+				DocumentaiObject: token,
+				PageNumber:       pageNum,
+				Text:             txt,
+			}
+
+			docAiPage.Tokens = append(docAiPage.Tokens, docAiToken)
+		}
+
+		// Collect lines
+		docAiPage.Lines = make([]*Line, 0, len(page.Lines))
+		for _, line := range page.Lines {
+			docAiLine := &Line{
+				DocumentaiObject: line,
+				PageNumber:       pageNum,
+				Text:             textFromLayout(line.Layout, doc.Text),
+			}
+
+			docAiPage.Lines = append(docAiPage.Lines, docAiLine)
+		}
+
+		// Collect paragraphs
+		docAiPage.Paragraphs = make([]*Paragraph, 0, len(page.Paragraphs))
+		for _, paragraph := range page.Paragraphs {
+			docAiParagraph := &Paragraph{
+				DocumentaiObject: paragraph,
+				PageNumber:       pageNum,
+				Text:             textFromLayout(paragraph.Layout, doc.Text),
+			}
+
+			docAiPage.Paragraphs = append(docAiPage.Paragraphs, docAiParagraph)
+		}
+
+		// Collect blocks
+		docAiPage.Blocks = make([]*Block, 0, len(page.Blocks))
+		for _, block := range page.Blocks {
+			docAiBlock := &Block{
+				DocumentaiObject: block,
+				PageNumber:       pageNum,
+				Text:             textFromLayout(block.Layout, doc.Text),
+			}
+
+			docAiPage.Blocks = append(docAiPage.Blocks, docAiBlock)
+		}
+
+		// Build hierarchy: lines -> paragraphs -> blocks
+		for _, line := range docAiPage.Lines {
+			line.Tokens = getChildElements(line, docAiPage.Tokens)
+		}
+
+		for _, paragraph := range docAiPage.Paragraphs {
+			paragraph.Lines = getChildElements(paragraph, docAiPage.Lines)
+		}
+
+		for _, block := range docAiPage.Blocks {
+			block.Paragraphs = getChildElements(block, docAiPage.Paragraphs)
+		}
+
+		result = append(result, docAiPage)
+	}
+
+	// Sort pages by number if there are multiple
+	if len(result) > 1 && result[0].PageNumber > 0 {
+		sort.Slice(result, func(i, j int) bool {
+			return result[i].PageNumber < result[j].PageNumber
+		})
+	}
+
+	return result
+}
+
+// getChildElements is a generic function that finds all child elements that are contained within a parent element
+// It works with any struct types that have a DocumentaiObject field with a Layout and TextAnchor
+func getChildElements[P any, C any](parent P, children []C) []C {
+	// Get the parent's layout from any supported type
+	var parentLayout *documentaipb.Document_Page_Layout
+
+	switch p := any(parent).(type) {
+	case *Line:
+		if p.DocumentaiObject != nil {
+			parentLayout = p.DocumentaiObject.Layout
+		}
+	case *Paragraph:
+		if p.DocumentaiObject != nil {
+			parentLayout = p.DocumentaiObject.Layout
+		}
+	case *Block:
+		if p.DocumentaiObject != nil {
+			parentLayout = p.DocumentaiObject.Layout
+		}
+	default:
+		return nil
+	}
+
+	// Validate parent layout
+	if parentLayout == nil || parentLayout.TextAnchor == nil || len(parentLayout.TextAnchor.TextSegments) == 0 {
+		return nil
+	}
+
+	// Get parent text range
+	parentStartIndex := parentLayout.TextAnchor.TextSegments[0].StartIndex
+	parentEndIndex := parentLayout.TextAnchor.TextSegments[0].EndIndex
+
+	var result []C
+	for _, child := range children {
+		// Get child layout
+		var childLayout *documentaipb.Document_Page_Layout
+
+		switch c := any(child).(type) {
+		case *Token:
+			if c.DocumentaiObject != nil {
+				childLayout = c.DocumentaiObject.Layout
+			}
+		case *Line:
+			if c.DocumentaiObject != nil {
+				childLayout = c.DocumentaiObject.Layout
+			}
+		case *Paragraph:
+			if c.DocumentaiObject != nil {
+				childLayout = c.DocumentaiObject.Layout
+			}
+		default:
+			continue
+		}
+
+		// Validate child layout
+		if childLayout == nil || childLayout.TextAnchor == nil || len(childLayout.TextAnchor.TextSegments) == 0 {
+			continue
+		}
+
+		// Check if child is within parent range
+		childStartIndex := childLayout.TextAnchor.TextSegments[0].StartIndex
+		childEndIndex := childLayout.TextAnchor.TextSegments[0].EndIndex
+
+		if childStartIndex >= parentStartIndex && childEndIndex <= parentEndIndex {
+			result = append(result, child)
+		}
+	}
+
+	return result
+}

--- a/pkg/gdocai/form_fields.go
+++ b/pkg/gdocai/form_fields.go
@@ -1,0 +1,41 @@
+package gdocai
+
+import (
+	"strings"
+
+	"cloud.google.com/go/documentai/apiv1/documentaipb"
+)
+
+// ExtractFormFields combines form fields from all pages into a single map
+// Handles duplicate keys by converting to arrays of values
+func ExtractFormFields(docProto *documentaipb.Document) map[string]interface{} {
+	fields := make(map[string]interface{})
+
+	for _, page := range docProto.Pages {
+		for _, field := range page.FormFields {
+			key := strings.TrimSpace(textFromLayout(field.FieldName, docProto.Text))
+			key = strings.TrimSuffix(key, ":")
+			value := strings.TrimSpace(textFromLayout(field.FieldValue, docProto.Text))
+
+			if key == "" {
+				continue
+			}
+
+			// Handle duplicate keys by converting to arrays
+			if existing, exists := fields[key]; exists {
+				switch v := existing.(type) {
+				case string:
+					if v != value {
+						fields[key] = []string{v, value}
+					}
+				case []string:
+					fields[key] = append(v, value)
+				}
+			} else {
+				fields[key] = value
+			}
+		}
+	}
+
+	return fields
+}

--- a/pkg/gdocai/gdocai.go
+++ b/pkg/gdocai/gdocai.go
@@ -1,0 +1,144 @@
+// Package gdocai provides a comprehensive integration with Google Document AI for document processing.
+//
+// This package's primary purpose is to process PDFs with Google Document AI and create searchable documents
+// by precisely overlaying OCR text at the exact position of each recognized word. The package handles the
+// complete workflow from raw PDF to a fully searchable document with the OCR text layer correctly positioned.
+//
+// The package converts Google Document AI's proprietary format into standard formats (plain text and HOCR),
+// while maintaining the positional data needed to reconstruct document layout. It also extracts form fields
+// from documents with form elements.
+//
+// Key Features:
+//
+// - Process PDFs with Google Document AI to extract text and structural information
+// - Create searchable PDFs with transparent OCR text overlaid at precise positions
+// - Extract form fields from documents with form elements
+// - Convert Document AI output to standard HOCR format for interoperability
+// - Access the full hierarchical structure of document content (blocks, paragraphs, lines, words)
+// - Extract page images for further processing
+//
+// Main Functions:
+//
+// - ProcessDocument: Sends a document to Google Document AI for processing
+// - DocumentFromProto: Converts Document AI response to a structured format
+// - DocumentHOCR: Processes a document and returns the structured data plus hOCR HTML
+// - DocumentHOCRFromPages: Processes multiple pages as a single document and returns the hOCR HTML
+// - ExtractFormFields: Gets form fields from the document as a map
+//
+// Usage Requirements:
+//
+// - Google Cloud project with Document AI API enabled
+// - Document AI processor configured for OCR
+// - Authentication via GOOGLE_APPLICATION_CREDENTIALS environment variable
+//
+package gdocai
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gardar/ocrchestra/pkg/hocr"
+)
+
+// DocumentHOCR processes a PDF with Document AI and returns our structured Document.
+// It handles the complete process from PDF bytes to a fully populated Document structure.
+// It returns:
+// - The internal Document representation
+// - The HOCR HTML as a string
+// - Any error encountered
+func DocumentHOCR(ctx context.Context, pdfBytes []byte, cfg *Config) (*Document, string, error) {
+	// Process the PDF using Google Document AI
+	rawDoc, err := ProcessDocument(ctx, pdfBytes, cfg)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to process document: %w", err)
+	}
+
+	// Convert to our structure
+	doc := DocumentFromProto(rawDoc)
+
+	// Return the document and generated hOCR HTML
+	return doc, doc.Hocr.HTML, nil
+}
+
+// DocumentHOCRFromPages processes multiple PDFs as individual pages
+// and combines them into a single document.
+//
+// Note: Unlike DocumentHOCR, this function does not yet create a complete
+// structured document. It creates a minimal structure with essential fields
+// sufficient for HOCR generation and image extraction, but does not fully
+// populate all hierarchical elements (blocks, paragraphs, etc.) that would
+// be available when processing a single multi-page document with DocumentFromProto.
+func DocumentHOCRFromPages(ctx context.Context, pagePdfBytesList [][]byte, cfg *Config) (*Document, string, error) {
+	var hocrPages []hocr.Page
+	var structuredPages []*Page
+	var fullText string
+
+	// Process each page individually
+	for i, pageBytes := range pagePdfBytesList {
+		// Process with Document AI
+		pageDoc, err := ProcessDocument(ctx, pageBytes, cfg)
+		if err != nil {
+			return nil, "", fmt.Errorf("failed to process page %d: %w", i+1, err)
+		}
+
+		if len(pageDoc.Pages) != 1 {
+			return nil, "", fmt.Errorf("expected 1 page in result for page %d, got %d", i+1, len(pageDoc.Pages))
+		}
+
+		// Create a structured page
+		pageNum := i + 1
+		docAiPage := &Page{
+			DocumentaiObject: pageDoc.Pages[0],
+			DocumentText:     pageDoc.Text,
+			PageNumber:       pageNum,
+			Text:             textFromLayout(pageDoc.Pages[0].Layout, pageDoc.Text),
+		}
+		structuredPages = append(structuredPages, docAiPage)
+
+		// Append this page's text to the full text
+		if i > 0 {
+			fullText += "\n\n"
+		}
+		fullText += pageDoc.Text
+
+		// Convert to HOCR page
+		hocrPage, err := CreateHOCRPage(pageDoc.Pages[0], pageDoc.Text, pageNum)
+		if err != nil {
+			return nil, "", fmt.Errorf("failed to create HOCR page %d: %w", i+1, err)
+		}
+
+		hocrPages = append(hocrPages, hocrPage)
+	}
+
+	// Create combined document
+	hocrDoc, err := CreateHOCRDocument(nil, hocrPages...)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to create HOCR document: %w", err)
+	}
+
+	// Generate HTML
+	hocrHTML, err := hocr.GenerateHOCRDocument(hocrDoc)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to generate HOCR HTML: %w", err)
+	}
+
+	// Create the Document structure with structured pages
+	doc := &Document{
+		Structured: &StructuredDocument{
+			Pages: structuredPages,
+		},
+		Text: &TextContent{
+			Content: fullText,
+		},
+		Hocr: &HocrContent{
+			Content: hocrDoc,
+			HTML:    hocrHTML,
+		},
+		FormFields: &FormData{
+			Fields: make(map[string]interface{}),
+		},
+		// Other fields as needed
+	}
+
+	return doc, hocrHTML, nil
+}

--- a/pkg/gdocai/helpers.go
+++ b/pkg/gdocai/helpers.go
@@ -1,0 +1,51 @@
+package gdocai
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+)
+
+// ToJSON converts various types to a pretty-printed JSON string
+// It handles both protocol buffer messages and regular Go structs
+func ToJSON(data interface{}) (string, error) {
+	switch v := data.(type) {
+	case proto.Message:
+		// For protocol buffer messages, use protojson
+		jsonData, err := protojson.Marshal(v)
+		if err != nil {
+			return "", err
+		}
+		return string(jsonData), nil
+
+	default:
+		// For regular Go structs, use standard json package
+		jsonData, err := json.MarshalIndent(v, "", "  ")
+		if err != nil {
+			return "", err
+		}
+		return string(jsonData), nil
+	}
+}
+
+// ExtractImageFromPage pulls out the image data from a Document AI page
+func ExtractImageFromPage(page *Page) ([]byte, error) {
+	if page == nil || page.DocumentaiObject == nil {
+		return nil, fmt.Errorf("no documentai page provided")
+	}
+
+	// Access the image from the wrapped Document AI page.
+	image := page.DocumentaiObject.GetImage()
+	if image == nil {
+		return nil, fmt.Errorf("no image found in documentai page")
+	}
+
+	content := image.GetContent()
+	if len(content) == 0 {
+		return nil, fmt.Errorf("image content is empty")
+	}
+
+	return content, nil
+}

--- a/pkg/gdocai/hocr.go
+++ b/pkg/gdocai/hocr.go
@@ -1,0 +1,496 @@
+package gdocai
+
+import (
+	"fmt"
+	"strings"
+
+	"cloud.google.com/go/documentai/apiv1/documentaipb"
+	"github.com/gardar/ocrchestra/pkg/hocr"
+)
+
+// CreateHOCRStruct converts a Document AI proto directly to the HOCR struct
+func CreateHOCRStruct(docProto *documentaipb.Document) (*hocr.HOCR, error) {
+	// Process each page into HOCR pages
+	var hocrPages []hocr.Page
+	for _, page := range docProto.Pages {
+		ocrPage, err := CreateHOCRPage(page, docProto.Text, int(page.PageNumber))
+		if err != nil {
+			return nil, err
+		}
+		hocrPages = append(hocrPages, ocrPage)
+	}
+
+	// Create the HOCR document with the pages
+	result, err := CreateHOCRDocument(docProto, hocrPages...)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+// CreateHOCRDocument creates an HOCR document structure, optionally with pages
+// If docProto is nil, default values will be used for document properties
+// If pages are provided, they will be added to the document
+func CreateHOCRDocument(docProto *documentaipb.Document, pages ...hocr.Page) (*hocr.HOCR, error) {
+	// Default values
+	docLang := "unknown"
+	pageCount := len(pages)
+
+	// If we have a proto document, use its properties
+	if docProto != nil {
+		langFromDoc := getDocumentLanguage(docProto)
+		if langFromDoc != "" {
+			docLang = langFromDoc
+		}
+		// Only use proto page count if no pages were provided
+		if pageCount == 0 && docProto.Pages != nil {
+			pageCount = len(docProto.Pages)
+		}
+	}
+
+	result := &hocr.HOCR{
+		Title:    "Document OCR",
+		Language: docLang,
+		Metadata: map[string]string{
+			"ocr-system":          "Document AI OCR",
+			"ocr-number-of-pages": fmt.Sprintf("%d", pageCount),
+			"ocr-capabilities":    "ocrp_lang ocr_page ocr_carea ocr_par ocr_line ocrx_word",
+			"ocr-langs":           docLang,
+		},
+		Pages: make([]hocr.Page, 0, len(pages)),
+	}
+
+	// Add any provided pages
+	if len(pages) > 0 {
+		result.Pages = append(result.Pages, pages...)
+
+		// Update document with language information from all pages
+		updateDocumentLanguages(result)
+	}
+
+	return result, nil
+}
+
+// CreateHOCRPage converts a single Document AI page to an HOCR page
+func CreateHOCRPage(page *documentaipb.Document_Page, fullText string, pageNumber int) (hocr.Page, error) {
+	ocrPage := hocr.Page{
+		ID:         fmt.Sprintf("page_%d", pageNumber),
+		PageNumber: pageNumber,
+		Metadata:   make(map[string]string),
+	}
+
+	// Extract page language if available
+	if len(page.DetectedLanguages) > 0 {
+		ocrPage.Lang = page.DetectedLanguages[0].LanguageCode
+	}
+
+	// Set bounding box if available
+	pageBox := getHocrBoundingBox(page.Layout, page.Dimension)
+	if pageBox != "" {
+		if bbox := hocr.ParseBoundingBoxFromTitle(pageBox); bbox != nil {
+			ocrPage.BBox = *bbox
+		}
+
+		// Extract image name if present
+		props := hocr.ParseTitle(pageBox)
+		if image, ok := props["image"]; ok && len(image) > 0 {
+			ocrPage.ImageName = image[0]
+		}
+	}
+
+	// Track which lines are assigned to avoid duplication
+	assignedLines := make(map[string]bool)
+
+	// Convert content areas (using ocr_carea class)
+	for aidx, area := range page.Blocks {
+		ocrArea := hocr.Area{
+			ID:       fmt.Sprintf("carea_%d_%d", pageNumber, aidx),
+			Metadata: make(map[string]string),
+		}
+
+		// Set bounding box
+		areaBox := getHocrBoundingBox(area.Layout, page.Dimension)
+		if areaBox != "" {
+			if bbox := hocr.ParseBoundingBoxFromTitle(areaBox); bbox != nil {
+				ocrArea.BBox = *bbox
+			}
+		}
+
+		// Process paragraphs within this area
+		for pidx, para := range page.Paragraphs {
+			// Skip if paragraph is not within this area
+			if !isElementInParent(para.Layout, area.Layout, fullText) {
+				continue
+			}
+
+			ocrParagraph := hocr.Paragraph{
+				ID:       fmt.Sprintf("par_%d_%d_%d", pageNumber, aidx, pidx),
+				Metadata: make(map[string]string),
+			}
+
+			paraBox := getHocrBoundingBox(para.Layout, page.Dimension)
+			if paraBox != "" {
+				if bbox := hocr.ParseBoundingBoxFromTitle(paraBox); bbox != nil {
+					ocrParagraph.BBox = *bbox
+				}
+			}
+
+			// Process lines within this paragraph
+			for lidx, line := range page.Lines {
+				// Skip if line is not within this paragraph
+				if !isElementInParent(line.Layout, para.Layout, fullText) {
+					continue
+				}
+
+				// Mark line as assigned to avoid duplication
+				lineKey := getLayoutKey(line.Layout)
+				assignedLines[lineKey] = true
+
+				ocrLine := convertLineFromProto(line, page, fullText, pageNumber, aidx, pidx, lidx)
+				ocrParagraph.Lines = append(ocrParagraph.Lines, ocrLine)
+			}
+
+			ocrParagraph.Words = nil // Words should be in lines
+			ocrArea.Paragraphs = append(ocrArea.Paragraphs, ocrParagraph)
+		}
+
+		ocrPage.Areas = append(ocrPage.Areas, ocrArea)
+	}
+
+	// Process paragraphs not assigned to any block or area
+	for pidx, para := range page.Paragraphs {
+		// Check if this paragraph is already assigned to a block or area
+		isAssigned := false
+		for _, block := range page.Blocks {
+			if isElementInParent(para.Layout, block.Layout, fullText) {
+				isAssigned = true
+				break
+			}
+		}
+
+		if isAssigned {
+			continue
+		}
+
+		ocrParagraph := hocr.Paragraph{
+			ID:       fmt.Sprintf("par_%d_direct_%d", pageNumber, pidx),
+			Metadata: make(map[string]string),
+		}
+
+		paraBox := getHocrBoundingBox(para.Layout, page.Dimension)
+		if paraBox != "" {
+			if bbox := hocr.ParseBoundingBoxFromTitle(paraBox); bbox != nil {
+				ocrParagraph.BBox = *bbox
+			}
+		}
+
+		// Process lines within this paragraph
+		for lidx, line := range page.Lines {
+			// Skip if line is not within this paragraph
+			if !isElementInParent(line.Layout, para.Layout, fullText) {
+				continue
+			}
+
+			// Mark line as assigned to avoid duplication
+			lineKey := getLayoutKey(line.Layout)
+			assignedLines[lineKey] = true
+
+			ocrLine := convertLineFromProto(line, page, fullText, pageNumber, 0, pidx, lidx)
+			ocrParagraph.Lines = append(ocrParagraph.Lines, ocrLine)
+		}
+
+		ocrParagraph.Words = nil // Words should be in lines
+		ocrPage.Paragraphs = append(ocrPage.Paragraphs, ocrParagraph)
+	}
+
+	// Add unassigned lines directly to the page
+	for lidx, line := range page.Lines {
+		lineKey := getLayoutKey(line.Layout)
+		if !assignedLines[lineKey] {
+			ocrLine := convertLineFromProto(line, page, fullText, pageNumber, 0, 0, lidx)
+			ocrPage.Lines = append(ocrPage.Lines, ocrLine)
+		}
+	}
+
+	return ocrPage, nil
+}
+
+// updateDocumentLanguages collects all languages used in the document and updates metadata
+func updateDocumentLanguages(result *hocr.HOCR) {
+	// Collect all languages used in the document
+	allLangs := make(map[string]bool)
+	allLangs[result.Language] = true
+
+	for _, page := range result.Pages {
+		if page.Lang != "" {
+			allLangs[page.Lang] = true
+		}
+
+		// Check Areas
+		for _, area := range page.Areas {
+			if area.Lang != "" {
+				allLangs[area.Lang] = true
+			}
+
+			// Check Paragraphs in Areas
+			for _, para := range area.Paragraphs {
+				if para.Lang != "" {
+					allLangs[para.Lang] = true
+				}
+
+				// Check Lines in Paragraphs
+				for _, line := range para.Lines {
+					if line.Lang != "" {
+						allLangs[line.Lang] = true
+					}
+
+					// Check Words in Lines
+					for _, word := range line.Words {
+						if word.Lang != "" {
+							allLangs[word.Lang] = true
+						}
+					}
+				}
+
+				// Check Words directly in Paragraphs
+				for _, word := range para.Words {
+					if word.Lang != "" {
+						allLangs[word.Lang] = true
+					}
+				}
+			}
+
+			// Check Lines directly in Areas
+			for _, line := range area.Lines {
+				if line.Lang != "" {
+					allLangs[line.Lang] = true
+				}
+
+				// Check Words in Lines
+				for _, word := range line.Words {
+					if word.Lang != "" {
+						allLangs[word.Lang] = true
+					}
+				}
+			}
+
+			// Check Words directly in Areas
+			for _, word := range area.Words {
+				if word.Lang != "" {
+					allLangs[word.Lang] = true
+				}
+			}
+		}
+
+		// Check Paragraphs directly in Page
+		for _, para := range page.Paragraphs {
+			if para.Lang != "" {
+				allLangs[para.Lang] = true
+			}
+
+			// Check Lines in Paragraphs
+			for _, line := range para.Lines {
+				if line.Lang != "" {
+					allLangs[line.Lang] = true
+				}
+
+				// Check Words in Lines
+				for _, word := range line.Words {
+					if word.Lang != "" {
+						allLangs[word.Lang] = true
+					}
+				}
+			}
+
+			// Check Words directly in Paragraphs
+			for _, word := range para.Words {
+				if word.Lang != "" {
+					allLangs[word.Lang] = true
+				}
+			}
+		}
+
+		// Check Lines directly in Page
+		for _, line := range page.Lines {
+			if line.Lang != "" {
+				allLangs[line.Lang] = true
+			}
+
+			// Check Words in Lines
+			for _, word := range line.Words {
+				if word.Lang != "" {
+					allLangs[word.Lang] = true
+				}
+			}
+		}
+	}
+
+	// Build language list for metadata
+	var langsList []string
+	for lang := range allLangs {
+		if lang != "" && lang != "unknown" {
+			langsList = append(langsList, lang)
+		}
+	}
+
+	if len(langsList) > 0 {
+		result.Metadata["ocr-langs"] = strings.Join(langsList, ", ")
+	}
+}
+
+// getHocrBoundingBox converts Document AI coordinates to hOCR coordinates
+// Takes normalized vertices (0-1) and scales them to actual pixel dimensions
+func getHocrBoundingBox(layout *documentaipb.Document_Page_Layout, dimension *documentaipb.Document_Page_Dimension) string {
+	if layout == nil || layout.BoundingPoly == nil || dimension == nil || len(layout.BoundingPoly.NormalizedVertices) < 4 {
+		return ""
+	}
+	vertices := layout.BoundingPoly.NormalizedVertices
+	minX := int(vertices[0].X*dimension.Width + 0.5)
+	minY := int(vertices[0].Y*dimension.Height + 0.5)
+	maxX := int(vertices[2].X*dimension.Width + 0.5)
+	maxY := int(vertices[2].Y*dimension.Height + 0.5)
+	return fmt.Sprintf("bbox %d %d %d %d", minX, minY, maxX, maxY)
+}
+
+// getDocumentLanguage finds the most common language in the document
+// by counting language occurrences across all elements
+func getDocumentLanguage(doc *documentaipb.Document) string {
+	// Create a frequency count of all languages in the document
+	langCount := make(map[string]int)
+
+	// Process all pages and tokens
+	for _, page := range doc.Pages {
+		// Process page languages
+		for _, lang := range page.DetectedLanguages {
+			langCount[lang.LanguageCode]++
+		}
+
+		// Process token languages
+		for _, token := range page.Tokens {
+			for _, lang := range token.DetectedLanguages {
+				langCount[lang.LanguageCode]++
+			}
+		}
+	}
+
+	// Find the most frequent language
+	var mostCommonLang string
+	var highestCount int
+
+	for lang, count := range langCount {
+		if count > highestCount {
+			highestCount = count
+			mostCommonLang = lang
+		}
+	}
+
+	return mostCommonLang
+}
+
+// Helper function to check if an element is contained within a parent
+func isElementInParent(elementLayout, parentLayout *documentaipb.Document_Page_Layout, fullText string) bool {
+	if elementLayout == nil || parentLayout == nil ||
+		elementLayout.TextAnchor == nil || parentLayout.TextAnchor == nil ||
+		len(elementLayout.TextAnchor.TextSegments) == 0 || len(parentLayout.TextAnchor.TextSegments) == 0 {
+		return false
+	}
+
+	elementStart := elementLayout.TextAnchor.TextSegments[0].StartIndex
+	elementEnd := elementLayout.TextAnchor.TextSegments[0].EndIndex
+	parentStart := parentLayout.TextAnchor.TextSegments[0].StartIndex
+	parentEnd := parentLayout.TextAnchor.TextSegments[0].EndIndex
+
+	return elementStart >= parentStart && elementEnd <= parentEnd
+}
+
+// Helper function to generate a unique key for a layout
+func getLayoutKey(layout *documentaipb.Document_Page_Layout) string {
+	if layout == nil || layout.TextAnchor == nil || len(layout.TextAnchor.TextSegments) == 0 {
+		return ""
+	}
+	return fmt.Sprintf("%d-%d", layout.TextAnchor.TextSegments[0].StartIndex,
+		layout.TextAnchor.TextSegments[0].EndIndex)
+}
+
+// Convert a proto line to an OCR line
+func convertLineFromProto(line *documentaipb.Document_Page_Line, page *documentaipb.Document_Page,
+	fullText string, pageNum, blockIdx, paraIdx, lineIdx int) hocr.Line {
+
+	ocrLine := hocr.Line{
+		ID:       fmt.Sprintf("line_%d_%d_%d_%d", pageNum, blockIdx, paraIdx, lineIdx),
+		Metadata: make(map[string]string),
+	}
+
+	// Extract line bounding box
+	lineBox := getHocrBoundingBox(line.Layout, page.Dimension)
+	if lineBox != "" {
+		if bbox := hocr.ParseBoundingBoxFromTitle(lineBox); bbox != nil {
+			ocrLine.BBox = *bbox
+		}
+
+		// Extract baseline if present
+		props := hocr.ParseTitle(lineBox)
+		if baseline, ok := props["baseline"]; ok && len(baseline) > 0 {
+			ocrLine.Baseline = strings.Join(baseline, " ")
+		}
+	}
+
+	// Extract line language
+	if len(line.DetectedLanguages) > 0 {
+		ocrLine.Lang = line.DetectedLanguages[0].LanguageCode
+	}
+
+	// Find tokens that belong to this line
+	for tidx, token := range page.Tokens {
+		if !isElementInParent(token.Layout, line.Layout, fullText) {
+			continue
+		}
+
+		// Clean token text
+		tokenText := textFromLayout(token.Layout, fullText)
+		cleanText := strings.TrimSpace(tokenText)
+		cleanText = strings.ReplaceAll(cleanText, "\n", " ")
+		cleanText = strings.ReplaceAll(cleanText, "\r", "")
+
+		// Trim trailing space if the token has a detected break
+		if token.DetectedBreak != nil &&
+			token.DetectedBreak.Type != documentaipb.Document_Page_Token_DetectedBreak_TYPE_UNSPECIFIED {
+			runesTok := []rune(cleanText)
+			if len(runesTok) > 0 {
+				last := runesTok[len(runesTok)-1]
+				if last == ' ' || last == '\n' || last == '\r' || last == '\t' {
+					cleanText = string(runesTok[:len(runesTok)-1])
+				}
+			}
+		}
+
+		word := hocr.Word{
+			ID:       fmt.Sprintf("word_%d_%d_%d_%d_%d", pageNum, blockIdx, paraIdx, lineIdx, tidx),
+			Text:     cleanText,
+			Metadata: make(map[string]string),
+		}
+
+		// Extract word bounding box
+		tokenBox := getHocrBoundingBox(token.Layout, page.Dimension)
+		if tokenBox != "" {
+			if bbox := hocr.ParseBoundingBoxFromTitle(tokenBox); bbox != nil {
+				word.BBox = *bbox
+			}
+		}
+
+		// Extract confidence
+		if token.Layout != nil {
+			word.Confidence = float64(token.Layout.Confidence * 100)
+		}
+
+		// Extract language
+		if len(token.DetectedLanguages) > 0 {
+			word.Lang = token.DetectedLanguages[0].LanguageCode
+		}
+
+		ocrLine.Words = append(ocrLine.Words, word)
+	}
+
+	return ocrLine
+}

--- a/pkg/gdocai/text.go
+++ b/pkg/gdocai/text.go
@@ -1,0 +1,41 @@
+package gdocai
+
+import (
+	"strings"
+
+	"cloud.google.com/go/documentai/apiv1/documentaipb"
+)
+
+// textFromProto extracts the full text from a Document AI proto
+func textFromProto(doc *documentaipb.Document) string {
+	if doc == nil {
+		return ""
+	}
+	return doc.Text
+}
+
+// textFromLayout extracts text from a layout's text anchor segments
+func textFromLayout(layout *documentaipb.Document_Page_Layout, fullText string) string {
+	if layout == nil || layout.TextAnchor == nil {
+		return ""
+	}
+	runes := []rune(fullText)
+	result := strings.Builder{}
+	totalRunes := len(runes)
+
+	for _, seg := range layout.TextAnchor.TextSegments {
+		start := int(seg.StartIndex)
+		end := int(seg.EndIndex)
+		if start < 0 {
+			start = 0
+		}
+		if end > totalRunes {
+			end = totalRunes
+		}
+		if start > end {
+			start = end
+		}
+		result.WriteString(string(runes[start:end]))
+	}
+	return result.String()
+}

--- a/pkg/gdocai/types.go
+++ b/pkg/gdocai/types.go
@@ -1,0 +1,95 @@
+package gdocai
+
+import (
+	"cloud.google.com/go/documentai/apiv1/documentaipb"
+	"github.com/gardar/ocrchestra/pkg/hocr"
+)
+
+// Document represents the primary result of OCR processing
+// It composes all the different components together
+type Document struct {
+	Raw        *RawDocument        // Original Document AI response
+	Structured *StructuredDocument // Processed document structure
+	Text       *TextContent        // Full text content
+	Hocr       *HocrContent        // hOCR representation
+	FormFields *FormData           // Extracted form fields
+}
+
+// RawDocument is a thin wrapper around the Google Document AI response
+type RawDocument struct {
+	*documentaipb.Document
+}
+
+// StructuredDocument represents the document content in a hierarchical structure
+type StructuredDocument struct {
+	Pages []*Page // Collection of pages
+}
+
+// TextContent wraps the full text of the document
+type TextContent struct {
+	Content string // The full text content of the document
+}
+
+// HocrContent wraps the hOCR data
+type HocrContent struct {
+	Content *hocr.HOCR // The hOCR representation
+	HTML    string
+}
+
+// FormData contains extracted form fields from the document
+type FormData struct {
+	Fields map[string]interface{} // Map of field names to values
+}
+
+// Page represents a single page in the document with its structural elements
+type Page struct {
+	DocumentaiObject *documentaipb.Document_Page // Original Document AI page
+	DocumentText     string                      // Source document text
+	Text             string                      // Text for this specific page
+	PageNumber       int                         // Page number (1-based)
+
+	FormFields []*FormField // Form fields found on this page
+	Lines      []*Line      // Text lines on this page
+	Paragraphs []*Paragraph // Paragraphs on this page
+	Blocks     []*Block     // Layout blocks on this page
+	Tokens     []*Token     // Individual tokens/words on this page
+}
+
+// Block represents a block of content on a page
+type Block struct {
+	DocumentaiObject *documentaipb.Document_Page_Block // Original Document AI block
+	PageNumber       int                               // Parent page number
+	Paragraphs       []*Paragraph                      // Child paragraphs in this block
+	Text             string                            // Text content of this block
+}
+
+// Paragraph represents a paragraph within a block
+type Paragraph struct {
+	DocumentaiObject *documentaipb.Document_Page_Paragraph // Original Document AI paragraph
+	PageNumber       int                                   // Parent page number
+	Lines            []*Line                               // Child lines in this paragraph
+	Text             string                                // Text content of this paragraph
+}
+
+// Line represents a line of text within a paragraph
+type Line struct {
+	DocumentaiObject *documentaipb.Document_Page_Line // Original Document AI line
+	PageNumber       int                              // Parent page number
+	Tokens           []*Token                         // Child tokens in this line
+	Text             string                           // Text content of this line
+}
+
+// Token represents a word or token within a line
+type Token struct {
+	DocumentaiObject *documentaipb.Document_Page_Token // Original Document AI token
+	PageNumber       int                               // Parent page number
+	Text             string                            // Text content of this token
+}
+
+// FormField represents a detected form field from a Form Document
+type FormField struct {
+	DocumentaiObject *documentaipb.Document_Page_FormField // Original Document AI form field
+	DocumentText     string                                // Source document text
+	FieldName        string                                // Extracted field name
+	FieldValue       string                                // Extracted field value
+}


### PR DESCRIPTION
gdocai is a package and a command-line tool for processing documents with Google Document AI and applying the OCR to the documents. 
gdocai extracts text, form fields, and hOCR data from PDFs using Google's Document AI API. 
It supports applying the OCR text from Google's Document AI to create searchable PDFs and can optionally extract a hOCR document, form field data and text.